### PR TITLE
fix bug

### DIFF
--- a/soul-web/src/main/java/org/dromara/soul/web/plugin/hystrix/DubboCommand.java
+++ b/soul-web/src/main/java/org/dromara/soul/web/plugin/hystrix/DubboCommand.java
@@ -92,9 +92,10 @@ public class DubboCommand extends HystrixObservableCommand<Void> {
 
     private Mono<Void> doRpcInvoke() {
         final Object result = dubboProxyService.genericInvoker(paramMap, dubboHandle);
-        exchange.getAttributes().put(Constants.DUBBO_RPC_RESULT, result);
-        exchange.getAttributes().put(Constants.CLIENT_RESPONSE_RESULT_TYPE,
-                ResultEnum.SUCCESS.getName());
+        if(result != null){
+            exchange.getAttributes().put(Constants.DUBBO_RPC_RESULT, result);
+        }
+        exchange.getAttributes().put(Constants.CLIENT_RESPONSE_RESULT_TYPE, ResultEnum.SUCCESS.getName());
         return chain.execute(exchange);
     }
 


### PR DESCRIPTION
dubbo调用返回null时

实际结果：
报空指针异常，gateway返回：dubbo rpc have error or fuse ing please check your param and  try again later

期待结果：
null或空
