### PR TITLE
fix:网关模块健康检查实现

### DIFF
--- a/soul-web/src/main/java/org/dromara/soul/web/config/SoulConfiguration.java
+++ b/soul-web/src/main/java/org/dromara/soul/web/config/SoulConfiguration.java
@@ -207,8 +207,8 @@ public class SoulConfiguration {
      */
     @Bean
     @Order(1)
-    public WebFilter paramWebFilter(WebEndpointProperties endpointProperties) {
-        return new ParamWebFilter(endpointProperties.getBasePath());
+    public WebFilter paramWebFilter() {
+        return new ParamWebFilter();
     }
 
     /**

--- a/soul-web/src/main/java/org/dromara/soul/web/filter/ParamWebFilter.java
+++ b/soul-web/src/main/java/org/dromara/soul/web/filter/ParamWebFilter.java
@@ -41,20 +41,11 @@ import java.util.Objects;
  */
 public class ParamWebFilter extends AbstractWebFilter {
 
-    private final String ignoreUrlPrefix;
-
-    public ParamWebFilter(String ignoreUrlPrefix) {
-        this.ignoreUrlPrefix = ignoreUrlPrefix;
-    }
 
     @Override
     protected Mono<Boolean> doFilter(final ServerWebExchange exchange, final WebFilterChain chain) {
         final ServerHttpRequest request = exchange.getRequest();
         final HttpHeaders headers = request.getHeaders();
-        final String urlPath = request.getURI().getPath();
-        if (urlPath.contains(ignoreUrlPrefix)) {
-            return Mono.just(true);
-        }
         final String upgrade = headers.getFirst("Upgrade");
         if (StringUtils.isBlank(upgrade) || !RpcTypeEnum.WEB_SOCKET.getName().equals(upgrade)) {
             final RequestDTO requestDTO = RequestDTO.transform(request);


### PR DESCRIPTION
原先的实现是没有问题的，但是当去掉DispatcherHandler的默认webHander后，所有请求都会被路由到soulWebHandler。会导致body为中requestDTO为空的异常。所以修改下健康检查实现。