### PR TITLE
fix httpcommand doesn't support get request with json format data

### DIFF
--- a/soul-common/src/main/java/org/dromara/soul/common/constant/Constants.java
+++ b/soul-common/src/main/java/org/dromara/soul/common/constant/Constants.java
@@ -61,6 +61,11 @@ public interface Constants {
     String DECODE = "UTF-8";
 
     /**
+     * The constant ENCODE.
+     */
+    String ENCODE = "UTF-8";
+
+    /**
      * The constant MODULE.
      */
     String MODULE = "module";

--- a/soul-common/src/main/java/org/dromara/soul/common/utils/GsonUtils.java
+++ b/soul-common/src/main/java/org/dromara/soul/common/utils/GsonUtils.java
@@ -36,7 +36,7 @@ import org.dromara.soul.common.constant.Constants;
 
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Type;
-import java.net.URLDecoder;
+import java.net.URLEncoder;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -158,7 +158,7 @@ public class GsonUtils {
             try {
                 stringBuilder.append(k)
                         .append("=")
-                        .append(URLDecoder.decode(v, Constants.DECODE))
+                        .append(URLEncoder.encode(v, Constants.ENCODE))
                         .append("&");
             } catch (UnsupportedEncodingException e) {
                 e.printStackTrace();

--- a/soul-web/src/main/java/org/dromara/soul/web/plugin/hystrix/HttpCommand.java
+++ b/soul-web/src/main/java/org/dromara/soul/web/plugin/hystrix/HttpCommand.java
@@ -45,6 +45,7 @@ import reactor.core.publisher.Mono;
 import rx.Observable;
 import rx.RxReactiveStreams;
 
+import java.net.URI;
 import java.time.Duration;
 import java.util.Objects;
 import java.util.Optional;
@@ -106,7 +107,7 @@ public class HttpCommand extends HystrixObservableCommand<Void> {
         if (requestDTO.getHttpMethod().equals(HttpMethodEnum.GET.getName())) {
             final String uri = getUrl(buildRealURL());
             LogUtils.debug(LOGGER, "you get request,The resulting url is :{}", () -> uri);
-            return WEB_CLIENT.get().uri(uri)
+            return WEB_CLIENT.get().uri(URI.create(uri))
                     .headers(httpHeaders -> {
                         httpHeaders.addAll(exchange.getRequest().getHeaders());
                         httpHeaders.remove(HttpHeaders.HOST);


### PR DESCRIPTION
user/listAllUserByPage?page=1&rows=10&term={"departmentId":2,"username":"","name":"","positionId":6}
例如这样的json格式的参数，无法被webclient正常请求，{}会被识别为占位符