### PR TITLE
when check url is fail,make a error message

### DIFF
--- a/soul-web/src/main/java/org/dromara/soul/web/cache/UpstreamCacheManager.java
+++ b/soul-web/src/main/java/org/dromara/soul/web/cache/UpstreamCacheManager.java
@@ -25,6 +25,7 @@ import org.dromara.soul.common.concurrent.SoulThreadFactory;
 import org.dromara.soul.common.dto.SelectorData;
 import org.dromara.soul.common.dto.convert.DivideUpstream;
 import org.dromara.soul.common.utils.GsonUtils;
+import org.dromara.soul.common.utils.LogUtils;
 import org.dromara.soul.common.utils.UrlUtils;
 import org.dromara.soul.web.config.SoulConfig;
 import org.slf4j.Logger;
@@ -162,6 +163,8 @@ public class UpstreamCacheManager {
             final boolean pass = UrlUtils.checkUrl(divideUpstream.getUpstreamUrl());
             if (pass) {
                 resultList.add(divideUpstream);
+            }else{
+                LogUtils.error(LOGGER, "check the url={} is fail ", divideUpstream::getUpstreamUrl);
             }
         }
         return resultList;


### PR DESCRIPTION
现在的情况是当diviide插件更新url的时候，回去做check，如果check不成功，这个url不会返回到upstreamList里面；如果upstreamList为空的时候，也只是提示 divide upstream config error,日志没有反映出哪个服务不可用，所以我在check失败后添加了个日志打印；
when check url is fail,make a error message ,like "check the url=127.0.0.1:8080 is fail"
