### PR TITLE
fix：HystrixProperties无法动态生效的问题

### DIFF
--- a/soul-web/src/main/java/org/dromara/soul/web/cache/HttpCacheHandler.java
+++ b/soul-web/src/main/java/org/dromara/soul/web/cache/HttpCacheHandler.java
@@ -17,6 +17,7 @@
 
 package org.dromara.soul.web.cache;
 
+import com.netflix.hystrix.strategy.properties.HystrixPropertiesFactory;
 import org.apache.commons.collections4.CollectionUtils;
 import org.dromara.soul.common.dto.AppAuthData;
 import org.dromara.soul.common.dto.PluginData;
@@ -119,6 +120,8 @@ class HttpCacheHandler extends AbstractLocalCacheManager {
             });
             RULE_MAP.clear();
             RULE_MAP.putAll(selectorToRules);
+            //Reset the HystrixPropertiesFactory cache, and HystrixProperties becomes dynamic
+            HystrixPropertiesFactory.reset();
         }
     }
 


### PR DESCRIPTION
HystrixPropertiesFactory缓存了每个CommandKey的配置，在soul admin动态改变时，清空缓存，使HystrixProperties动态生效