### PR TITLE
配置中心支持Nacos和阿里云ACM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ target
 *.tmp
 Thumbs.db
 *.DS_Store
+.factorypath

--- a/soul-admin/pom.xml
+++ b/soul-admin/pom.xml
@@ -153,9 +153,6 @@
 		</dependency>
 
 	</dependencies>
-	<properties>
-		<m2e.apt.activation>jdt_apt</m2e.apt.activation>
-	</properties>
 	<!--多环境 Maven profile整合Spring profile -->
 	<profiles>
 		<profile>

--- a/soul-admin/pom.xml
+++ b/soul-admin/pom.xml
@@ -1,217 +1,225 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>soul</artifactId>
-        <groupId>org.dromara</groupId>
-        <version>2.1.2-RELEASE</version>
-    </parent>
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>soul-admin</artifactId>
-    <dependencies>
-        <dependency>
-            <groupId>org.dromara</groupId>
-            <artifactId>soul-common</artifactId>
-        </dependency>
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<artifactId>soul</artifactId>
+		<groupId>org.dromara</groupId>
+		<version>2.1.2-RELEASE</version>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>soul-admin</artifactId>
+	<dependencies>
+		<dependency>
+			<groupId>org.dromara</groupId>
+			<artifactId>soul-common</artifactId>
+		</dependency>
 
-        <dependency>
-            <groupId>org.dromara</groupId>
-            <artifactId>soul-configuration</artifactId>
-            <exclusions>
-                <exclusion>
-                    <artifactId>spring-boot-starter-data-redis</artifactId>
-                    <groupId>org.springframework.boot</groupId>
-                </exclusion>
-            </exclusions>      
-        </dependency>
+		<dependency>
+			<groupId>org.dromara</groupId>
+			<artifactId>soul-configuration</artifactId>
+			<exclusions>
+				<exclusion>
+					<artifactId>spring-boot-starter-data-redis</artifactId>
+					<groupId>org.springframework.boot</groupId>
+				</exclusion>
+			</exclusions>
+		</dependency>
 
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
-        </dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
 
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-logging</artifactId>
-        </dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-logging</artifactId>
+		</dependency>
 
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-websocket</artifactId>
-        </dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-websocket</artifactId>
+		</dependency>
 
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+		</dependency>
 
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-actuator</artifactId>
-        </dependency>
-
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-thymeleaf</artifactId>
-        </dependency>
-
-        <!--自动配置-->
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <optional>true</optional>
-        </dependency>
-
-        <dependency>
-            <groupId>org.projectreactor</groupId>
-            <artifactId>reactor-spring</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.mybatis.spring.boot</groupId>
-            <artifactId>mybatis-spring-boot-starter</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>commons-dbcp</groupId>
-            <artifactId>commons-dbcp</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-collections4</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.github.pagehelper</groupId>
-            <artifactId>pagehelper</artifactId>
-            <version>5.1.1</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.101tec</groupId>
-            <artifactId>zkclient</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>com.esotericsoftware</groupId>
-            <artifactId>kryo-shaded</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.dyuproject.protostuff</groupId>
-            <artifactId>protostuff-core</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.dyuproject.protostuff</groupId>
-            <artifactId>protostuff-runtime</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.caucho</groupId>
-            <artifactId>hessian</artifactId>
-        </dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
 
 
-        <dependency>
-            <groupId>org.mapstruct</groupId>
-            <artifactId>mapstruct-jdk8</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.mapstruct</groupId>
-            <artifactId>mapstruct-processor</artifactId>
-        </dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-thymeleaf</artifactId>
+		</dependency>
 
-    </dependencies>
+		<!--自动配置 -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
 
-    <!--多环境 Maven profile整合Spring profile-->
-    <profiles>
-        <profile>
-            <id>local</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <properties>
-                <env>local</env>
-            </properties>
-        </profile>
-        <profile>
-            <id>dev</id>
-            <properties>
-                <env>dev</env>
-            </properties>
-        </profile>
-        <profile>
-            <id>prod</id>
-            <properties>
-                <env>prod</env>
-            </properties>
-        </profile>
-    </profiles>
+		<dependency>
+			<groupId>org.projectreactor</groupId>
+			<artifactId>reactor-spring</artifactId>
+		</dependency>
 
-    <build>
-        <finalName>soul-admin</finalName>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                    <encoding>UTF-8</encoding>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
-                <configuration>
-                    <mainClass>org.dromara.soul.admin.SoulAdminApplication</mainClass>
-                    <executable>true</executable>
-                </configuration>
-            </plugin>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-resources-plugin</artifactId>
-                <version>2.6</version>
-                <configuration>
-                    <encoding>UTF-8</encoding>
-                    <useDefaultDelimiters>true</useDefaultDelimiters>
-                </configuration>
-            </plugin>
+		<dependency>
+			<groupId>org.mybatis.spring.boot</groupId>
+			<artifactId>mybatis-spring-boot-starter</artifactId>
+		</dependency>
 
-            <!-- maven install 跳过测试  等价于命令 mvn install -Dmaven.test.skip = true-->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+		<dependency>
+			<groupId>commons-dbcp</groupId>
+			<artifactId>commons-dbcp</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>mysql</groupId>
+			<artifactId>mysql-connector-java</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-collections4</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.github.pagehelper</groupId>
+			<artifactId>pagehelper</artifactId>
+			<version>5.1.1</version>
+		</dependency>
+		
+		<dependency>
+			<groupId>com.alibaba.nacos</groupId>
+			<artifactId>nacos-client</artifactId>
+			<version>1.2.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.101tec</groupId>
+			<artifactId>zkclient</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>log4j</groupId>
+					<artifactId>log4j</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
+			<groupId>com.esotericsoftware</groupId>
+			<artifactId>kryo-shaded</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.dyuproject.protostuff</groupId>
+			<artifactId>protostuff-core</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.dyuproject.protostuff</groupId>
+			<artifactId>protostuff-runtime</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.caucho</groupId>
+			<artifactId>hessian</artifactId>
+		</dependency>
+
+
+		<dependency>
+			<groupId>org.mapstruct</groupId>
+			<artifactId>mapstruct-jdk8</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.mapstruct</groupId>
+			<artifactId>mapstruct-processor</artifactId>
+		</dependency>
+
+	</dependencies>
+	<properties>
+		<m2e.apt.activation>jdt_apt</m2e.apt.activation>
+	</properties>
+	<!--多环境 Maven profile整合Spring profile -->
+	<profiles>
+		<profile>
+			<id>local</id>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+			</activation>
+			<properties>
+				<env>local</env>
+			</properties>
+		</profile>
+		<profile>
+			<id>dev</id>
+			<properties>
+				<env>dev</env>
+			</properties>
+		</profile>
+		<profile>
+			<id>prod</id>
+			<properties>
+				<env>prod</env>
+			</properties>
+		</profile>
+	</profiles>
+
+	<build>
+		<finalName>soul-admin</finalName>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+					<encoding>UTF-8</encoding>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+					<mainClass>org.dromara.soul.admin.SoulAdminApplication</mainClass>
+					<executable>true</executable>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-resources-plugin</artifactId>
+				<version>2.6</version>
+				<configuration>
+					<encoding>UTF-8</encoding>
+					<useDefaultDelimiters>true</useDefaultDelimiters>
+				</configuration>
+			</plugin>
+
+			<!-- maven install 跳过测试 等价于命令 mvn install -Dmaven.test.skip = true -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/soul-admin/src/main/java/org/dromara/soul/admin/config/DataSyncConfiguration.java
+++ b/soul-admin/src/main/java/org/dromara/soul/admin/config/DataSyncConfiguration.java
@@ -3,9 +3,11 @@ package org.dromara.soul.admin.config;
 import org.I0Itec.zkclient.ZkClient;
 import org.dromara.soul.admin.listener.DataChangedListener;
 import org.dromara.soul.admin.listener.http.HttpLongPollingDataChangedListener;
+import org.dromara.soul.admin.listener.nacos.NacosDataChangedListener;
 import org.dromara.soul.admin.listener.websocket.WebsocketCollector;
 import org.dromara.soul.admin.listener.websocket.WebsocketDataChangedListener;
 import org.dromara.soul.admin.listener.zookeeper.ZookeeperDataChangedListener;
+import org.dromara.soul.configuration.nacos.NacosConfiguration;
 import org.dromara.soul.configuration.zookeeper.ZookeeperConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -13,6 +15,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.web.socket.server.standard.ServerEndpointExporter;
+
+import com.alibaba.nacos.api.config.ConfigService;
 
 /**
  * The type Data sync configuration.
@@ -54,6 +58,22 @@ public class DataSyncConfiguration {
         }
     }
 
+    /**
+     * The type Nacos listener
+     * 
+     * @author Chenxj
+     * @date 2020年3月12日-下午1:40:20
+     */
+    @Configuration
+    @ConditionalOnMissingBean(DataChangedListener.class)
+    @ConditionalOnProperty(name = "soul.sync.strategy", havingValue = "nacos")
+    @Import(NacosConfiguration.class)
+    static class NacosListener {
+        @Bean
+        public DataChangedListener dataChangedListener(final ConfigService configService) {
+        	return new NacosDataChangedListener(configService);
+        }
+    }
 
     /**
      * The WebsocketListener.
@@ -93,5 +113,4 @@ public class DataSyncConfiguration {
             return new ServerEndpointExporter();
         }
     }
-
 }

--- a/soul-admin/src/main/java/org/dromara/soul/admin/listener/nacos/NacosDataChangedListener.java
+++ b/soul-admin/src/main/java/org/dromara/soul/admin/listener/nacos/NacosDataChangedListener.java
@@ -5,6 +5,7 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
@@ -244,7 +245,15 @@ public class NacosDataChangedListener implements DataChangedListener{
 			META_DATA.keySet().removeAll(set);
 			break;
 		default:
-			changed.stream().forEach(meta->META_DATA.put(meta.getPath(), meta));
+			changed.stream().forEach(meta->{
+				META_DATA
+				.values()
+				.stream()
+				.filter(md->Objects.equals(md.getId(), meta.getId()))
+				.forEach(md->META_DATA.remove(md.getPath()));
+				
+				META_DATA.put(meta.getPath(), meta);
+			});
 			break;
 		}
 		publishConfig(gson, metaDataId, META_DATA);

--- a/soul-admin/src/main/java/org/dromara/soul/admin/listener/nacos/NacosDataChangedListener.java
+++ b/soul-admin/src/main/java/org/dromara/soul/admin/listener/nacos/NacosDataChangedListener.java
@@ -233,13 +233,12 @@ public class NacosDataChangedListener implements DataChangedListener{
 		Gson gson=new Gson();
 		updateMetaDataMap(gson, getConfig(metaDataId), null);
 		changed.stream().forEach(meta->{
-			String metaKey=buildMetaKey(meta);
 			switch (eventType) {
 			case DELETE:
-				META_DATA.remove(metaKey);
+				META_DATA.remove(meta.getPath());
 				break;
 			default:
-				META_DATA.put(metaKey, meta);
+				META_DATA.put(meta.getPath(), meta);
 				break;
 			}
 		});
@@ -273,9 +272,6 @@ public class NacosDataChangedListener implements DataChangedListener{
 		publishConfig(gson, ruleDataId, RULE_MAP);
 	}
 	
-	private String buildMetaKey(MetaData meta) {
-		return meta.getAppName()+'-'+meta.getServiceName()+meta.getMethodName();
-	}
 	private static interface ErrorAction{
 		public void act(Object o);
 	}

--- a/soul-admin/src/main/java/org/dromara/soul/admin/listener/nacos/NacosDataChangedListener.java
+++ b/soul-admin/src/main/java/org/dromara/soul/admin/listener/nacos/NacosDataChangedListener.java
@@ -25,12 +25,10 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 /**
- * © 2015-2020 Chenxj Copyright
- * 类    名：NacosDataChangedListener
- * 类 描 述：
- * 作    者：Chenxj
- * 邮    箱：chenios@foxmail.com
- * 日    期：2020年3月12日-上午10:00:14
+ * Use nacos to push data changes.
+ *
+ * @author chenxj
+ * @date 2020年3月12日-上午10:00:14
  */
 public class NacosDataChangedListener implements DataChangedListener{
 	private static final ConcurrentMap<String, PluginData> PLUGIN_MAP = Maps.newConcurrentMap();

--- a/soul-admin/src/main/java/org/dromara/soul/admin/listener/nacos/NacosDataChangedListener.java
+++ b/soul-admin/src/main/java/org/dromara/soul/admin/listener/nacos/NacosDataChangedListener.java
@@ -1,0 +1,282 @@
+package org.dromara.soul.admin.listener.nacos;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
+
+import org.dromara.soul.admin.listener.DataChangedListener;
+import org.dromara.soul.common.dto.AppAuthData;
+import org.dromara.soul.common.dto.MetaData;
+import org.dromara.soul.common.dto.PluginData;
+import org.dromara.soul.common.dto.RuleData;
+import org.dromara.soul.common.dto.SelectorData;
+import org.dromara.soul.common.enums.DataEventTypeEnum;
+
+import com.alibaba.nacos.api.config.ConfigService;
+import com.google.common.collect.Maps;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+/**
+ * © 2015-2020 Chenxj Copyright
+ * 类    名：NacosDataChangedListener
+ * 类 描 述：
+ * 作    者：Chenxj
+ * 邮    箱：chenios@foxmail.com
+ * 日    期：2020年3月12日-上午10:00:14
+ */
+public class NacosDataChangedListener implements DataChangedListener{
+	private static final ConcurrentMap<String, PluginData> PLUGIN_MAP = Maps.newConcurrentMap();
+	private static final ConcurrentMap<String, List<SelectorData>> SELECTOR_MAP = Maps.newConcurrentMap();
+	private static final ConcurrentMap<String, List<RuleData>> RULE_MAP = Maps.newConcurrentMap();
+	private static final ConcurrentMap<String, AppAuthData> AUTH_MAP = Maps.newConcurrentMap();
+	private static final ConcurrentMap<String, MetaData> META_DATA = Maps.newConcurrentMap();
+	private static final Comparator<SelectorData> selectorCp=Comparator.comparing(SelectorData::getSort);
+	private static final Comparator<RuleData> ruleCp=Comparator.comparing(RuleData::getSort);
+	private static final String group="DEFAULT_GROUP";
+	private static final String pluginDataId="soul.plugin.json";
+	private static final String selectorDataId="soul.selector.json";
+	private static final String ruleDataId="soul.rule.json";
+	private static final String authDataId="soul.auth.json";
+	private static final String metaDataId="soul.meta.json";
+	private final ConfigService configService;
+	
+	public NacosDataChangedListener(ConfigService configService) {
+		this.configService=configService;
+	}
+	private void updateAuthMap(Gson gson,String configInfo,ErrorAction ea) {
+		try {
+			JsonObject jo=gson.fromJson(configInfo, JsonObject.class);
+			Set<String>newSet=new HashSet<>();
+			for(Entry<String, JsonElement>e:jo.entrySet()) {
+				newSet.add(e.getKey());
+				AUTH_MAP.put(e.getKey(), gson.fromJson(e.getValue(), AppAuthData.class));
+			}
+			Set<String>set=new HashSet<>(AUTH_MAP.keySet());
+			set.removeAll(newSet);
+			//移除AUTH_MAP中多余keys
+			if(!set.isEmpty()) {
+				set.forEach(k->AUTH_MAP.remove(k));
+			}
+		}catch (Exception e) {
+			if(ea!=null) {
+				ea.act(e);
+			}
+		}
+	}
+	private void updatePluginMap(Gson gson,String configInfo,ErrorAction ea) {
+		try {
+			JsonObject jo=gson.fromJson(configInfo, JsonObject.class);
+			Set<String>newSet=new HashSet<>();
+			for(Entry<String, JsonElement>e:jo.entrySet()) {
+				newSet.add(e.getKey());
+				PLUGIN_MAP.put(e.getKey(), gson.fromJson(e.getValue(), PluginData.class));
+			}
+			Set<String>set=new HashSet<>(PLUGIN_MAP.keySet());
+			set.removeAll(newSet);
+			//移除PLUGIN_MAP中多余keys
+			if(!set.isEmpty()) {
+				set.forEach(k->PLUGIN_MAP.remove(k));
+			}
+		}catch (Exception e) {
+			if(ea!=null) {
+				ea.act(e);
+			}
+		}
+	}
+	private void updateSelectorMap(Gson gson,String configInfo,ErrorAction ea) {
+		try {
+			JsonObject jo=gson.fromJson(configInfo, JsonObject.class);
+			Set<String>newSet=new HashSet<>();
+			for(Entry<String, JsonElement>e:jo.entrySet()) {
+				List<SelectorData>ls=new ArrayList<>();
+				e.getValue().getAsJsonArray().forEach(je->ls.add(gson.fromJson(je, SelectorData.class)));
+				newSet.add(e.getKey());
+				SELECTOR_MAP.put(e.getKey(), ls);
+			}
+			Set<String>set=new HashSet<>(SELECTOR_MAP.keySet());
+			set.removeAll(newSet);
+			//移除SELECTOR_MAP中多余keys
+			if(!set.isEmpty()) {
+				set.forEach(k->SELECTOR_MAP.remove(k));
+			}
+		}catch (Exception e) {
+			if(ea!=null) {
+				ea.act(e);
+			}
+		}
+	}
+	private void updateMetaDataMap(Gson gson,String configInfo,ErrorAction ea) {
+		try {
+			JsonObject jo=gson.fromJson(configInfo, JsonObject.class);
+			Set<String>newSet=new HashSet<>();
+			for(Entry<String, JsonElement>e:jo.entrySet()) {
+				newSet.add(e.getKey());
+				META_DATA.put(e.getKey(), gson.fromJson(e.getValue(), MetaData.class));
+			}
+			Set<String>set=new HashSet<>(META_DATA.keySet());
+			set.removeAll(newSet);
+			//移除AUTH_MAP中多余keys
+			if(!set.isEmpty()) {
+				set.forEach(k->META_DATA.remove(k));
+			}
+		}catch (Exception e) {
+			if(ea!=null) {
+				ea.act(e);
+			}
+		}
+	}
+	private void updateRuleMap(Gson gson,String configInfo,ErrorAction ea) {
+		try {
+			JsonObject jo=gson.fromJson(configInfo, JsonObject.class);
+			Set<String>newSet=new HashSet<>();
+			for(Entry<String, JsonElement>e:jo.entrySet()) {
+				List<RuleData>ls=new ArrayList<>();
+				e.getValue().getAsJsonArray().forEach(je->ls.add(gson.fromJson(je, RuleData.class)));
+				newSet.add(e.getKey());
+				RULE_MAP.put(e.getKey(), ls);
+			}
+			Set<String>set=new HashSet<>(RULE_MAP.keySet());
+			set.removeAll(newSet);
+			//移除RULE_MAP中多余keys
+			if(!set.isEmpty()) {
+				set.forEach(k->RULE_MAP.remove(k));
+			}
+		}catch (Exception e) {
+			if(ea!=null) {
+				ea.act(e);
+			}
+		}
+	}
+	
+	private String getConfig(String dataId) {
+		try {
+			return configService.getConfig(dataId, group, 6000);
+		}catch (Exception e) {
+			return "{}";
+		}
+	}
+	private void publishConfig(Gson gson,String dataId,Object data) {
+		try {
+			configService.publishConfig(dataId, group, gson.toJson(data));
+		}catch (Exception e) {
+		}
+	}
+	
+	@Override
+	public void onAppAuthChanged(List<AppAuthData> changed, DataEventTypeEnum eventType) {
+		Gson gson=new Gson();
+		updateAuthMap(gson, getConfig(authDataId), null);
+		changed.stream().forEach(appAuth->{
+			switch (eventType) {
+			case DELETE:
+				AUTH_MAP.remove(appAuth.getAppKey());
+				break;
+			default:
+				AUTH_MAP.put(appAuth.getAppKey(), appAuth);
+				break;
+			}
+		});
+		publishConfig(gson, authDataId, AUTH_MAP);
+	}
+	@Override
+	public void onPluginChanged(List<PluginData> changed, DataEventTypeEnum eventType) {
+		Gson gson=new Gson();
+		updatePluginMap(gson, getConfig(pluginDataId), null);
+		changed.stream().forEach(plugin->{
+			switch (eventType) {
+			case DELETE:
+				PLUGIN_MAP.remove(plugin.getName());
+				break;
+			default:
+				PLUGIN_MAP.put(plugin.getName(), plugin);
+				break;
+			}
+		});
+		publishConfig(gson, pluginDataId, PLUGIN_MAP);
+	}
+	@Override
+	public void onSelectorChanged(List<SelectorData> changed, DataEventTypeEnum eventType) {
+		Gson gson=new Gson();
+		updateSelectorMap(gson, getConfig(selectorDataId), null);
+		changed.stream().forEach(selector->{
+			List<SelectorData>ls=null;
+			switch (eventType) {
+			case DELETE:
+				ls=SELECTOR_MAP
+				.getOrDefault(selector.getPluginName(), new ArrayList<>())
+				.stream()
+				.filter(s->!s.getId().equals(selector.getId()))
+				.collect(Collectors.toList());
+				break;
+			default:
+				ls=SELECTOR_MAP
+				.getOrDefault(selector.getPluginName(), new ArrayList<>())
+				.stream()
+				.filter(s->!s.getId().equals(selector.getId()))
+				.collect(Collectors.toList());
+				ls.add(selector);
+				break;
+			}
+			SELECTOR_MAP.put(selector.getPluginName(), ls.stream().sorted(selectorCp).collect(Collectors.toList()));
+		});
+		publishConfig(gson, selectorDataId, SELECTOR_MAP);
+	}
+	@Override
+	public void onMetaDataChanged(List<MetaData> changed, DataEventTypeEnum eventType) {
+		Gson gson=new Gson();
+		updateMetaDataMap(gson, getConfig(metaDataId), null);
+		changed.stream().forEach(meta->{
+			String metaKey=buildMetaKey(meta);
+			switch (eventType) {
+			case DELETE:
+				META_DATA.remove(metaKey);
+				break;
+			default:
+				META_DATA.put(metaKey, meta);
+				break;
+			}
+		});
+		publishConfig(gson, metaDataId, META_DATA);
+	}
+	@Override
+	public void onRuleChanged(List<RuleData> changed, DataEventTypeEnum eventType) {
+		Gson gson=new Gson();
+		updateRuleMap(gson, getConfig(ruleDataId), null);
+		changed.stream().forEach(rule->{
+			List<RuleData>ls=null;
+			switch (eventType) {
+			case DELETE:
+				ls=RULE_MAP
+				.getOrDefault(rule.getSelectorId(), new ArrayList<>())
+				.stream()
+				.filter(s->!s.getId().equals(rule.getSelectorId()))
+				.collect(Collectors.toList());
+				break;
+			default:
+				ls=RULE_MAP
+				.getOrDefault(rule.getSelectorId(), new ArrayList<>())
+				.stream()
+				.filter(s->!s.getId().equals(rule.getSelectorId()))
+				.collect(Collectors.toList());
+				ls.add(rule);
+				break;
+			}
+			RULE_MAP.put(rule.getSelectorId(), ls.stream().sorted(ruleCp).collect(Collectors.toList()));
+		});
+		publishConfig(gson, ruleDataId, RULE_MAP);
+	}
+	
+	private String buildMetaKey(MetaData meta) {
+		return meta.getAppName()+'-'+meta.getServiceName()+meta.getMethodName();
+	}
+	private static interface ErrorAction{
+		public void act(Object o);
+	}
+}

--- a/soul-admin/src/main/java/org/dromara/soul/admin/service/impl/AppAuthServiceImpl.java
+++ b/soul-admin/src/main/java/org/dromara/soul/admin/service/impl/AppAuthServiceImpl.java
@@ -222,7 +222,7 @@ public class AppAuthServiceImpl implements AppAuthService {
         if (CollectionUtils.isNotEmpty(appAuthDOList)) {
             List<AppAuthData> dataList = appAuthDOList.stream().map(this::buildByEntity).collect(Collectors.toList());
             eventPublisher.publishEvent(new DataChangedEvent(ConfigGroupEnum.APP_AUTH,
-                    DataEventTypeEnum.UPDATE,
+                    DataEventTypeEnum.REFRESH,
                     dataList));
         }
         return SoulAdminResult.success();

--- a/soul-admin/src/main/java/org/dromara/soul/admin/service/impl/MetaDataServiceImpl.java
+++ b/soul-admin/src/main/java/org/dromara/soul/admin/service/impl/MetaDataServiceImpl.java
@@ -407,14 +407,8 @@ public class MetaDataServiceImpl implements MetaDataService {
             return AdminConstants.PARAMS_ERROR;
         }
         final MetaDataDO exist = metaDataMapper.findByPath(metaDataDTO.getPath());
-        if (StringUtils.isBlank(metaDataDTO.getId())) {
-            if (Objects.nonNull(exist)) {
-                return AdminConstants.DATA_PATH_IS_EXIST;
-            }
-        } else {
-            if (Objects.isNull(exist) || !exist.getId().equals(metaDataDTO.getId())) {
-                return AdminConstants.DATA_PATH_IS_EXIST;
-            }
+        if(exist!=null&&!exist.getId().equals(metaDataDTO.getId())) {
+        	return AdminConstants.DATA_PATH_IS_EXIST;
         }
         return StringUtils.EMPTY;
     }

--- a/soul-admin/src/main/java/org/dromara/soul/admin/service/init/LocalDataSourceLoader.java
+++ b/soul-admin/src/main/java/org/dromara/soul/admin/service/init/LocalDataSourceLoader.java
@@ -17,7 +17,11 @@
 
 package org.dromara.soul.admin.service.init;
 
-import org.apache.commons.lang3.StringUtils;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.DriverManager;
+
 import org.apache.ibatis.io.Resources;
 import org.apache.ibatis.jdbc.ScriptRunner;
 import org.slf4j.Logger;
@@ -26,11 +30,6 @@ import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.InstantiationAwareBeanPostProcessor;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.stereotype.Component;
-
-import java.io.Reader;
-import java.nio.charset.StandardCharsets;
-import java.sql.Connection;
-import java.sql.DriverManager;
 
 /**
  * for execute schema sql file.
@@ -56,11 +55,8 @@ public class LocalDataSourceLoader implements InstantiationAwareBeanPostProcesso
         // If jdbcUrl in the configuration file specifies the soul database, it is removed,
         // because the soul database does not need to be specified when executing the SQL file,
         // otherwise the soul database will be disconnected when the soul database does not exist
-        String jdbcUrl = properties.getUrl();
-        jdbcUrl = StringUtils.replace(jdbcUrl, "/soul?", "?");
-
         try {
-            Connection connection = DriverManager.getConnection(jdbcUrl, properties.getUsername(), properties.getPassword());
+            Connection connection = DriverManager.getConnection(properties.getUrl(), properties.getUsername(), properties.getPassword());
             this.execute(connection);
         } catch (Exception e) {
             LOGGER.info(e.getMessage());

--- a/soul-admin/src/main/resources/META-INF/schema.sql
+++ b/soul-admin/src/main/resources/META-INF/schema.sql
@@ -1,7 +1,7 @@
 
-CREATE DATABASE  IF NOT EXISTS  `soul`  DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ;
-
-USE `soul`;
+--CREATE DATABASE  IF NOT EXISTS  `soul`  DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ;
+--
+--USE `soul`;
 
 CREATE TABLE IF NOT EXISTS `app_auth`  (
   `id` varchar(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '主键id',
@@ -141,15 +141,15 @@ CREATE TABLE  IF NOT EXISTS `meta_data` (
 SET FOREIGN_KEY_CHECKS = 1;
 
 /*plugin*/
-INSERT IGNORE INTO `soul`.`plugin` (`id`, `name`,`role`, `enabled`, `date_created`, `date_updated`) VALUES ('1', 'sign','0', '0', '2018-06-14 10:17:35', '2018-06-14 10:17:35');
-INSERT IGNORE INTO `soul`.`plugin` (`id`, `name`,`role`,`enabled`, `date_created`, `date_updated`) VALUES ('2', 'waf', '0','0', '2018-06-23 10:26:30', '2018-06-13 15:43:10');
-INSERT IGNORE INTO `soul`.`plugin` (`id`, `name`,`role`, `enabled`, `date_created`, `date_updated`) VALUES ('3', 'rewrite', '0','0', '2018-06-23 10:26:34', '2018-06-25 13:59:31');
-INSERT IGNORE INTO `soul`.`plugin` (`id`, `name`,`role`,`config`,`enabled`, `date_created`, `date_updated`) VALUES ('4', 'rate_limiter','0','{"master":"mymaster","mode":"Standalone","url":"192.168.1.1:6379","password":"abc"}', '0', '2018-06-23 10:26:37', '2018-06-13 15:34:48');
-INSERT IGNORE INTO `soul`.`plugin` (`id`, `name`,`role`, `enabled`, `date_created`, `date_updated`) VALUES ('5', 'divide', '0','1', '2018-06-25 10:19:10', '2018-06-13 13:56:04');
-INSERT IGNORE INTO `soul`.`plugin` (`id`, `name`,`role`,`enabled`, `date_created`, `date_updated`) VALUES ('6', 'dubbo','0', '1', '2018-06-23 10:26:41', '2018-06-11 10:11:47');
-INSERT IGNORE INTO `soul`.`plugin` (`id`, `name`,`role`,`config`,`enabled`, `date_created`, `date_updated`) VALUES ('7', 'monitor', '0','{"userName":"xiaoyu","database":"databases","url":"http://localhost:8086","password":"test222"}','0', '2018-06-25 13:47:57', '2018-06-25 13:47:57');
-INSERT IGNORE INTO `soul`.`plugin` (`id`, `name`,`role`, `enabled`, `date_created`, `date_updated`) VALUES ('8', 'springCloud','0', '1', '2018-06-25 13:47:57', '2018-06-25 13:47:57');
-INSERT IGNORE INTO `soul`.`plugin` (`id`, `name`,`role`, `enabled`, `date_created`, `date_updated`) VALUES ('9', 'hystrix', '0','1', '2020-01-15 10:19:10', '2020-01-15 10:19:10');
+INSERT IGNORE INTO `plugin` (`id`, `name`,`role`, `enabled`, `date_created`, `date_updated`) VALUES ('1', 'sign','0', '0', '2018-06-14 10:17:35', '2018-06-14 10:17:35');
+INSERT IGNORE INTO `plugin` (`id`, `name`,`role`,`enabled`, `date_created`, `date_updated`) VALUES ('2', 'waf', '0','0', '2018-06-23 10:26:30', '2018-06-13 15:43:10');
+INSERT IGNORE INTO `plugin` (`id`, `name`,`role`, `enabled`, `date_created`, `date_updated`) VALUES ('3', 'rewrite', '0','0', '2018-06-23 10:26:34', '2018-06-25 13:59:31');
+INSERT IGNORE INTO `plugin` (`id`, `name`,`role`,`config`,`enabled`, `date_created`, `date_updated`) VALUES ('4', 'rate_limiter','0','{"master":"mymaster","mode":"Standalone","url":"192.168.1.1:6379","password":"abc"}', '0', '2018-06-23 10:26:37', '2018-06-13 15:34:48');
+INSERT IGNORE INTO `plugin` (`id`, `name`,`role`, `enabled`, `date_created`, `date_updated`) VALUES ('5', 'divide', '0','1', '2018-06-25 10:19:10', '2018-06-13 13:56:04');
+INSERT IGNORE INTO `plugin` (`id`, `name`,`role`,`enabled`, `date_created`, `date_updated`) VALUES ('6', 'dubbo','0', '1', '2018-06-23 10:26:41', '2018-06-11 10:11:47');
+INSERT IGNORE INTO `plugin` (`id`, `name`,`role`,`config`,`enabled`, `date_created`, `date_updated`) VALUES ('7', 'monitor', '0','{"userName":"xiaoyu","database":"databases","url":"http://localhost:8086","password":"test222"}','0', '2018-06-25 13:47:57', '2018-06-25 13:47:57');
+INSERT IGNORE INTO `plugin` (`id`, `name`,`role`, `enabled`, `date_created`, `date_updated`) VALUES ('8', 'springCloud','0', '1', '2018-06-25 13:47:57', '2018-06-25 13:47:57');
+INSERT IGNORE INTO `plugin` (`id`, `name`,`role`, `enabled`, `date_created`, `date_updated`) VALUES ('9', 'hystrix', '0','1', '2020-01-15 10:19:10', '2020-01-15 10:19:10');
 
 /**user**/
-INSERT IGNORE INTO `soul`.`dashboard_user` (`id`, `user_name`, `password`, `role`, `enabled`, `date_created`, `date_updated`) VALUES ('1', 'admin', '123456', '1', '1', '2018-06-23 15:12:22', '2018-06-23 15:12:23');
+INSERT IGNORE INTO `dashboard_user` (`id`, `user_name`, `password`, `role`, `enabled`, `date_created`, `date_updated`) VALUES ('1', 'admin', '123456', '1', '1', '2018-06-23 15:12:22', '2018-06-23 15:12:23');

--- a/soul-admin/src/main/resources/application-local.yml
+++ b/soul-admin/src/main/resources/application-local.yml
@@ -10,11 +10,11 @@ spring:
     prefix: classpath:/static/
     suffix: .html
   datasource:
-    url: jdbc:mysql://localhost:3307/soul?useUnicode=true&characterEncoding=utf-8&serverTimezone=GMT&failOverReadOnly=false&autoReconnect=true&useSSL=false
+    url: jdbc:mysql://localhost:3306/soul2?useUnicode=true&characterEncoding=utf-8&serverTimezone=GMT&failOverReadOnly=false&autoReconnect=true&useSSL=false
     username: root
     password: 123456
     dbcp2:
-      driver-class-name: com.mysql.jdbc.Driver
+      driver-class-name: com.mysql.cj.jdbc.Driver
 
 mybatis:
   config-location: classpath:/mybatis/mybatis-config.xml
@@ -26,11 +26,20 @@ soul:
     register: false
     zookeeperUrl: localhost:2181
   sync:
-    strategy: websocket
+    strategy: nacos
 #      zookeeper:
 #        url: localhost:2181
 #        sessionTimeout: 5000
 #        connectionTimeout: 2000
+    nacos:
+      url: localhost:8848
+      namespace: 1c10d748-af86-43b9-8265-75f487d20c6c
+      acm:
+        enabled: false
+        endpoint: acm.aliyun.com
+        namespace: 
+        accessKey: 
+        secretKey: 
 
 logging:
   level:

--- a/soul-bootstrap/pom.xml
+++ b/soul-bootstrap/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>com.alibaba.nacos</groupId>
             <artifactId>nacos-client</artifactId>
-            <version>1.1.4</version>
+            <version>1.2.0</version>
         </dependency>
 
         <dependency>

--- a/soul-bootstrap/src/main/resources/application-local.yml
+++ b/soul-bootstrap/src/main/resources/application-local.yml
@@ -14,7 +14,7 @@ spring:
 
 soul :
     sync:
-        strategy: websocket
+        strategy: nacos
         websocket :
              url: ws://localhost:9095/websocket
 #        zookeeper:
@@ -23,13 +23,24 @@ soul :
 #             connectionTimeout: 2000
 #        http:
 #             url : http://localhost:9095
+        nacos:
+              url: localhost:8848
+              namespace: 1c10d748-af86-43b9-8265-75f487d20c6c
+              acm:
+                enabled: false
+                endpoint: acm.aliyun.com
+                namespace: 
+                accessKey: 
+                secretKey: 
 
 
-#eureka:
+eureka:
 #  instance:
 #    leaseRenewalIntervalInSeconds: 10
 #    leaseExpirationDurationInSeconds: 30
-#  client:
+  client:
+     registerWithEureka: false
+     fetchRegistry: false
 #    serviceUrl:
 #      defaultZone: http://eureka.didispace.com/eureka/
 

--- a/soul-common/pom.xml
+++ b/soul-common/pom.xml
@@ -47,7 +47,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>[2.9.10,)</version>
         </dependency>
 
         <dependency>

--- a/soul-common/src/main/java/org/dromara/soul/common/dto/MetaData.java
+++ b/soul-common/src/main/java/org/dromara/soul/common/dto/MetaData.java
@@ -6,7 +6,8 @@ import java.io.Serializable;
 
 @Data
 public class MetaData implements Serializable {
-
+    private String id;
+    
     private String appName;
 
     private String path;

--- a/soul-configuration/pom.xml
+++ b/soul-configuration/pom.xml
@@ -1,75 +1,79 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>soul</artifactId>
-        <groupId>org.dromara</groupId>
-        <version>2.1.2-RELEASE</version>
-    </parent>
-    <modelVersion>4.0.0</modelVersion>
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<artifactId>soul</artifactId>
+		<groupId>org.dromara</groupId>
+		<version>2.1.2-RELEASE</version>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
 
-    <artifactId>soul-configuration</artifactId>
+	<artifactId>soul-configuration</artifactId>
 
-    <dependencies>
+	<dependencies>
 
-        <dependency>
-            <groupId>org.dromara</groupId>
-            <artifactId>soul-common</artifactId>
-        </dependency>
+		<dependency>
+			<groupId>org.dromara</groupId>
+			<artifactId>soul-common</artifactId>
+		</dependency>
 
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-redis</artifactId>
-        </dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-redis</artifactId>
+		</dependency>
 
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-autoconfigure</artifactId>
-        </dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+		</dependency>
 
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <optional>true</optional>
-        </dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>com.alibaba.nacos</groupId>
+			<artifactId>nacos-client</artifactId>
+			<version>1.2.0</version>
+		</dependency>
+		<dependency>
+			<groupId>com.101tec</groupId>
+			<artifactId>zkclient</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>log4j</groupId>
+					<artifactId>log4j</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.esotericsoftware</groupId>
+			<artifactId>kryo-shaded</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.dyuproject.protostuff</groupId>
+			<artifactId>protostuff-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.dyuproject.protostuff</groupId>
+			<artifactId>protostuff-runtime</artifactId>
+		</dependency>
 
-        <dependency>
-            <groupId>com.101tec</groupId>
-            <artifactId>zkclient</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.esotericsoftware</groupId>
-            <artifactId>kryo-shaded</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.dyuproject.protostuff</groupId>
-            <artifactId>protostuff-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.dyuproject.protostuff</groupId>
-            <artifactId>protostuff-runtime</artifactId>
-        </dependency>
+		<dependency>
+			<groupId>com.caucho</groupId>
+			<artifactId>hessian</artifactId>
+		</dependency>
 
-        <dependency>
-            <groupId>com.caucho</groupId>
-            <artifactId>hessian</artifactId>
-        </dependency>
-
-    </dependencies>
+	</dependencies>
 
 </project>

--- a/soul-configuration/src/main/java/org/dromara/soul/configuration/nacos/NacosACMConfig.java
+++ b/soul-configuration/src/main/java/org/dromara/soul/configuration/nacos/NacosACMConfig.java
@@ -1,0 +1,12 @@
+package org.dromara.soul.configuration.nacos;
+
+import lombok.Data;
+
+@Data
+public class NacosACMConfig {
+	private boolean enabled;
+	private String endpoint;
+	private String namespace;
+	private String accessKey;
+	private String secretKey;
+}

--- a/soul-configuration/src/main/java/org/dromara/soul/configuration/nacos/NacosConfig.java
+++ b/soul-configuration/src/main/java/org/dromara/soul/configuration/nacos/NacosConfig.java
@@ -1,0 +1,13 @@
+package org.dromara.soul.configuration.nacos;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import lombok.Data;
+
+@Data
+@ConfigurationProperties(prefix="soul.sync.nacos")
+public class NacosConfig {
+	private String url;
+	private String namespace;
+	private NacosACMConfig acm;
+}

--- a/soul-configuration/src/main/java/org/dromara/soul/configuration/nacos/NacosConfiguration.java
+++ b/soul-configuration/src/main/java/org/dromara/soul/configuration/nacos/NacosConfiguration.java
@@ -1,0 +1,45 @@
+package org.dromara.soul.configuration.nacos;
+
+import java.util.Properties;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+
+import com.alibaba.nacos.api.NacosFactory;
+import com.alibaba.nacos.api.PropertyKeyConst;
+import com.alibaba.nacos.api.config.ConfigService;
+
+/**
+ * NacosConfiguration
+ * 
+ * @author Chenxj
+ * @date 2020年3月12日-下午12:05:50
+ */
+@EnableConfigurationProperties(NacosConfig.class)
+public class NacosConfiguration {
+	
+	/**
+	 * register configService in spring ioc.
+	 * 
+	 * @param nacosConfig the nacos configuration
+	 * @return ConfigService {@linkplain ConfigService}
+	 * @throws Exception
+	 * @date 2020年3月12日 下午1:44:55
+	 */
+	@Bean
+	public ConfigService nacosConfigService(final NacosConfig nacosConfig) throws Exception {
+		Properties properties=new Properties();
+		if(nacosConfig.getAcm()!=null&&nacosConfig.getAcm().isEnabled()) {
+			//使用阿里云ACM服务
+			properties.put(PropertyKeyConst.ENDPOINT, nacosConfig.getAcm().getEndpoint());
+			properties.put(PropertyKeyConst.NAMESPACE, nacosConfig.getAcm().getNamespace());
+			//使用子账户ACM管理权限
+			properties.put(PropertyKeyConst.ACCESS_KEY, nacosConfig.getAcm().getAccessKey());
+			properties.put(PropertyKeyConst.SECRET_KEY, nacosConfig.getAcm().getSecretKey());
+		}else {
+			properties.put(PropertyKeyConst.SERVER_ADDR, nacosConfig.getUrl());
+			properties.put(PropertyKeyConst.NAMESPACE, nacosConfig.getNamespace());
+		}
+		return NacosFactory.createConfigService(properties);
+	}
+}

--- a/soul-web/src/main/java/org/dromara/soul/web/cache/AbstractLocalCacheManager.java
+++ b/soul-web/src/main/java/org/dromara/soul/web/cache/AbstractLocalCacheManager.java
@@ -118,6 +118,15 @@ public abstract class AbstractLocalCacheManager implements LocalCacheManager {
     }
 
     /**
+     * Config plugin.
+     *
+     * @param pluginDataList the plugin data
+     */
+    void configPlugin(final PluginData pluginData) {
+        PluginConfigHandler.INS.initPluginConfig(pluginData);
+    }
+
+    /**
      * Find  meta data by uri.
      *
      * @param uri the uri

--- a/soul-web/src/main/java/org/dromara/soul/web/cache/AbstractLocalCacheManager.java
+++ b/soul-web/src/main/java/org/dromara/soul/web/cache/AbstractLocalCacheManager.java
@@ -139,18 +139,32 @@ public abstract class AbstractLocalCacheManager implements LocalCacheManager {
      */
     void initDubboRef(final List<MetaData> metaDataList) {
         for (MetaData metaData : metaDataList) {
-            if (RpcTypeEnum.DUBBO.getName().equals(metaData.getRpcType())) {
-                MetaData exist = META_DATA.get(metaData.getPath());
-                if (Objects.isNull(exist)
-                        || Objects.isNull(ApplicationConfigCache.getInstance().get(exist.getServiceName()).isInit())) {
-                    //第一次初始化
-                    ApplicationConfigCache.getInstance().initRef(metaData);
-                } else {
-                    if (!exist.getServiceName().equals(metaData.getServiceName())
-                            || !exist.getRpcExt().equals(metaData.getRpcExt())) {
-                        //有更新
-                        ApplicationConfigCache.getInstance().build(metaData);
-                    }
+            updateRubboRef(metaData);
+        }
+    }
+    /**
+     * Init dubbo ref.
+     *
+     * @param metaDataList the meta data array list
+     */
+    void initDubboRef(final MetaData...metaDataList) {
+        for (MetaData metaData : metaDataList) {
+            updateRubboRef(metaData);
+        }
+    }
+    
+    void updateRubboRef(MetaData metaData) {
+    	if (RpcTypeEnum.DUBBO.getName().equals(metaData.getRpcType())) {
+            MetaData exist = META_DATA.get(metaData.getPath());
+            if (Objects.isNull(exist)
+                    || Objects.isNull(ApplicationConfigCache.getInstance().get(exist.getServiceName()).isInit())) {
+                //第一次初始化
+                ApplicationConfigCache.getInstance().initRef(metaData);
+            } else {
+                if (!exist.getServiceName().equals(metaData.getServiceName())
+                        || !exist.getRpcExt().equals(metaData.getRpcExt())) {
+                    //有更新
+                    ApplicationConfigCache.getInstance().build(metaData);
                 }
             }
         }

--- a/soul-web/src/main/java/org/dromara/soul/web/cache/NacosCacheHandler.java
+++ b/soul-web/src/main/java/org/dromara/soul/web/cache/NacosCacheHandler.java
@@ -62,7 +62,9 @@ public class NacosCacheHandler extends CommonCacheHandler {
 			Set<String>set=new HashSet<>(PLUGIN_MAP.keySet());
 			for(Entry<String, JsonElement>e:jo.entrySet()) {
 				set.remove(e.getKey());
-				PLUGIN_MAP.put(e.getKey(), gson.fromJson(e.getValue(), PluginData.class));
+				PluginData pluginData=gson.fromJson(e.getValue(), PluginData.class);
+				configPlugin(pluginData);
+				PLUGIN_MAP.put(e.getKey(), pluginData);
 			}
 			PLUGIN_MAP.keySet().removeAll(set);
 		}catch (Exception e) {

--- a/soul-web/src/main/java/org/dromara/soul/web/cache/NacosCacheHandler.java
+++ b/soul-web/src/main/java/org/dromara/soul/web/cache/NacosCacheHandler.java
@@ -43,17 +43,12 @@ public class NacosCacheHandler extends CommonCacheHandler {
 	protected void updateAuthMap(Gson gson,String configInfo,ErrorAction ea) {
 		try {
 			JsonObject jo=gson.fromJson(configInfo, JsonObject.class);
-			Set<String>newSet=new HashSet<>();
+			Set<String>set=new HashSet<>(AUTH_MAP.keySet());
 			for(Entry<String, JsonElement>e:jo.entrySet()) {
-				newSet.add(e.getKey());
+				set.remove(e.getKey());
 				AUTH_MAP.put(e.getKey(), gson.fromJson(e.getValue(), AppAuthData.class));
 			}
-			Set<String>set=new HashSet<>(AUTH_MAP.keySet());
-			set.removeAll(newSet);
-			//移除AUTH_MAP中多余keys
-			if(!set.isEmpty()) {
-				set.forEach(k->AUTH_MAP.remove(k));
-			}
+			AUTH_MAP.keySet().removeAll(set);
 		}catch (Exception e) {
 			if(ea!=null) {
 				ea.act(e);
@@ -63,17 +58,12 @@ public class NacosCacheHandler extends CommonCacheHandler {
 	protected void updatePluginMap(Gson gson,String configInfo,ErrorAction ea) {
 		try {
 			JsonObject jo=gson.fromJson(configInfo, JsonObject.class);
-			Set<String>newSet=new HashSet<>();
+			Set<String>set=new HashSet<>(PLUGIN_MAP.keySet());
 			for(Entry<String, JsonElement>e:jo.entrySet()) {
-				newSet.add(e.getKey());
+				set.remove(e.getKey());
 				PLUGIN_MAP.put(e.getKey(), gson.fromJson(e.getValue(), PluginData.class));
 			}
-			Set<String>set=new HashSet<>(PLUGIN_MAP.keySet());
-			set.removeAll(newSet);
-			//移除PLUGIN_MAP中多余keys
-			if(!set.isEmpty()) {
-				set.forEach(k->PLUGIN_MAP.remove(k));
-			}
+			PLUGIN_MAP.keySet().removeAll(set);
 		}catch (Exception e) {
 			if(ea!=null) {
 				ea.act(e);
@@ -83,19 +73,14 @@ public class NacosCacheHandler extends CommonCacheHandler {
 	protected void updateSelectorMap(Gson gson,String configInfo,ErrorAction ea) {
 		try {
 			JsonObject jo=gson.fromJson(configInfo, JsonObject.class);
-			Set<String>newSet=new HashSet<>();
+			Set<String>set=new HashSet<>(SELECTOR_MAP.keySet());
 			for(Entry<String, JsonElement>e:jo.entrySet()) {
+				set.remove(e.getKey());
 				List<SelectorData>ls=new ArrayList<>();
 				e.getValue().getAsJsonArray().forEach(je->ls.add(gson.fromJson(je, SelectorData.class)));
-				newSet.add(e.getKey());
 				SELECTOR_MAP.put(e.getKey(), ls);
 			}
-			Set<String>set=new HashSet<>(SELECTOR_MAP.keySet());
-			set.removeAll(newSet);
-			//移除SELECTOR_MAP中多余keys
-			if(!set.isEmpty()) {
-				set.forEach(k->SELECTOR_MAP.remove(k));
-			}
+			SELECTOR_MAP.keySet().removeAll(set);
 		}catch (Exception e) {
 			if(ea!=null) {
 				ea.act(e);
@@ -105,17 +90,12 @@ public class NacosCacheHandler extends CommonCacheHandler {
 	protected void updateMetaDataMap(Gson gson,String configInfo,ErrorAction ea) {
 		try {
 			JsonObject jo=gson.fromJson(configInfo, JsonObject.class);
-			Set<String>newSet=new HashSet<>();
+			Set<String>set=new HashSet<>(META_DATA.keySet());
 			for(Entry<String, JsonElement>e:jo.entrySet()) {
-				newSet.add(e.getKey());
+				set.remove(e.getKey());
 				META_DATA.put(e.getKey(), gson.fromJson(e.getValue(), MetaData.class));
 			}
-			Set<String>set=new HashSet<>(META_DATA.keySet());
-			set.removeAll(newSet);
-			//移除AUTH_MAP中多余keys
-			if(!set.isEmpty()) {
-				set.forEach(k->META_DATA.remove(k));
-			}
+			META_DATA.keySet().removeAll(set);
 		}catch (Exception e) {
 			if(ea!=null) {
 				ea.act(e);
@@ -125,19 +105,14 @@ public class NacosCacheHandler extends CommonCacheHandler {
 	protected void updateRuleMap(Gson gson,String configInfo,ErrorAction ea) {
 		try {
 			JsonObject jo=gson.fromJson(configInfo, JsonObject.class);
-			Set<String>newSet=new HashSet<>();
+			Set<String>set=new HashSet<>(RULE_MAP.keySet());
 			for(Entry<String, JsonElement>e:jo.entrySet()) {
+				set.remove(e.getKey());
 				List<RuleData>ls=new ArrayList<>();
 				e.getValue().getAsJsonArray().forEach(je->ls.add(gson.fromJson(je, RuleData.class)));
-				newSet.add(e.getKey());
 				RULE_MAP.put(e.getKey(), ls);
 			}
-			Set<String>set=new HashSet<>(RULE_MAP.keySet());
-			set.removeAll(newSet);
-			//移除RULE_MAP中多余keys
-			if(!set.isEmpty()) {
-				set.forEach(k->RULE_MAP.remove(k));
-			}
+			RULE_MAP.keySet().removeAll(set);
 		}catch (Exception e) {
 			if(ea!=null) {
 				ea.act(e);

--- a/soul-web/src/main/java/org/dromara/soul/web/cache/NacosCacheHandler.java
+++ b/soul-web/src/main/java/org/dromara/soul/web/cache/NacosCacheHandler.java
@@ -1,0 +1,196 @@
+package org.dromara.soul.web.cache;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.Executor;
+
+import org.dromara.soul.common.dto.AppAuthData;
+import org.dromara.soul.common.dto.MetaData;
+import org.dromara.soul.common.dto.PluginData;
+import org.dromara.soul.common.dto.RuleData;
+import org.dromara.soul.common.dto.SelectorData;
+
+import com.alibaba.nacos.api.config.ConfigService;
+import com.alibaba.nacos.api.config.listener.Listener;
+import com.google.common.collect.Maps;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+/**
+ * NacosCacheHandler
+ * 
+ * @author Chenxj
+ * @date 2020年3月12日-下午2:07:12
+ */
+public class NacosCacheHandler extends CommonCacheHandler {
+	protected static final String group="DEFAULT_GROUP";
+	protected static final String pluginDataId="soul.plugin.json";
+	protected static final String selectorDataId="soul.selector.json";
+	protected static final String ruleDataId="soul.rule.json";
+	protected static final String authDataId="soul.auth.json";
+	protected static final String metaDataId="soul.meta.json";
+	protected final ConfigService configService;
+	protected final Map<String, List<Listener>>listeners=Maps.newConcurrentMap();
+	
+	public NacosCacheHandler(final ConfigService configService) {
+		this.configService=configService;
+	}
+	protected void updateAuthMap(Gson gson,String configInfo,ErrorAction ea) {
+		try {
+			JsonObject jo=gson.fromJson(configInfo, JsonObject.class);
+			Set<String>newSet=new HashSet<>();
+			for(Entry<String, JsonElement>e:jo.entrySet()) {
+				newSet.add(e.getKey());
+				AUTH_MAP.put(e.getKey(), gson.fromJson(e.getValue(), AppAuthData.class));
+			}
+			Set<String>set=new HashSet<>(AUTH_MAP.keySet());
+			set.removeAll(newSet);
+			//移除AUTH_MAP中多余keys
+			if(!set.isEmpty()) {
+				set.forEach(k->AUTH_MAP.remove(k));
+			}
+		}catch (Exception e) {
+			if(ea!=null) {
+				ea.act(e);
+			}
+		}
+	}
+	protected void updatePluginMap(Gson gson,String configInfo,ErrorAction ea) {
+		try {
+			JsonObject jo=gson.fromJson(configInfo, JsonObject.class);
+			Set<String>newSet=new HashSet<>();
+			for(Entry<String, JsonElement>e:jo.entrySet()) {
+				newSet.add(e.getKey());
+				PLUGIN_MAP.put(e.getKey(), gson.fromJson(e.getValue(), PluginData.class));
+			}
+			Set<String>set=new HashSet<>(PLUGIN_MAP.keySet());
+			set.removeAll(newSet);
+			//移除PLUGIN_MAP中多余keys
+			if(!set.isEmpty()) {
+				set.forEach(k->PLUGIN_MAP.remove(k));
+			}
+		}catch (Exception e) {
+			if(ea!=null) {
+				ea.act(e);
+			}
+		}
+	}
+	protected void updateSelectorMap(Gson gson,String configInfo,ErrorAction ea) {
+		try {
+			JsonObject jo=gson.fromJson(configInfo, JsonObject.class);
+			Set<String>newSet=new HashSet<>();
+			for(Entry<String, JsonElement>e:jo.entrySet()) {
+				List<SelectorData>ls=new ArrayList<>();
+				e.getValue().getAsJsonArray().forEach(je->ls.add(gson.fromJson(je, SelectorData.class)));
+				newSet.add(e.getKey());
+				SELECTOR_MAP.put(e.getKey(), ls);
+			}
+			Set<String>set=new HashSet<>(SELECTOR_MAP.keySet());
+			set.removeAll(newSet);
+			//移除SELECTOR_MAP中多余keys
+			if(!set.isEmpty()) {
+				set.forEach(k->SELECTOR_MAP.remove(k));
+			}
+		}catch (Exception e) {
+			if(ea!=null) {
+				ea.act(e);
+			}
+		}
+	}
+	protected void updateMetaDataMap(Gson gson,String configInfo,ErrorAction ea) {
+		try {
+			JsonObject jo=gson.fromJson(configInfo, JsonObject.class);
+			Set<String>newSet=new HashSet<>();
+			for(Entry<String, JsonElement>e:jo.entrySet()) {
+				newSet.add(e.getKey());
+				META_DATA.put(e.getKey(), gson.fromJson(e.getValue(), MetaData.class));
+			}
+			Set<String>set=new HashSet<>(META_DATA.keySet());
+			set.removeAll(newSet);
+			//移除AUTH_MAP中多余keys
+			if(!set.isEmpty()) {
+				set.forEach(k->META_DATA.remove(k));
+			}
+		}catch (Exception e) {
+			if(ea!=null) {
+				ea.act(e);
+			}
+		}
+	}
+	protected void updateRuleMap(Gson gson,String configInfo,ErrorAction ea) {
+		try {
+			JsonObject jo=gson.fromJson(configInfo, JsonObject.class);
+			Set<String>newSet=new HashSet<>();
+			for(Entry<String, JsonElement>e:jo.entrySet()) {
+				List<RuleData>ls=new ArrayList<>();
+				e.getValue().getAsJsonArray().forEach(je->ls.add(gson.fromJson(je, RuleData.class)));
+				newSet.add(e.getKey());
+				RULE_MAP.put(e.getKey(), ls);
+			}
+			Set<String>set=new HashSet<>(RULE_MAP.keySet());
+			set.removeAll(newSet);
+			//移除RULE_MAP中多余keys
+			if(!set.isEmpty()) {
+				set.forEach(k->RULE_MAP.remove(k));
+			}
+		}catch (Exception e) {
+			if(ea!=null) {
+				ea.act(e);
+			}
+		}
+	}
+	
+	protected String getConfig(String dataId) {
+		try {
+			return configService.getConfig(dataId, group, 6000);
+		}catch (Exception e) {
+			return "{}";
+		}
+	}
+	protected String getConfigAndSignListener(String dataId,Listener listener) {
+		try {
+			return configService.getConfigAndSignListener(dataId, group, 6000, listener);
+		}catch (Exception e) {
+			return "{}";
+		}
+	}
+	protected void publishConfig(Gson gson,String dataId,Object data) {
+		try {
+			configService.publishConfig(dataId, group, gson.toJson(data));
+		}catch (Exception e) {
+		}
+	}
+	protected String buildMetaKey(MetaData meta) {
+		return meta.getAppName()+'-'+meta.getServiceName()+meta.getMethodName();
+	}
+	protected void watcherData(String dataId,OnChange oc) {
+		try {
+			Listener listener=new Listener() {
+				@Override
+				public void receiveConfigInfo(String configInfo) {
+					oc.change(configInfo);
+				}
+				@Override
+				public Executor getExecutor() {
+					return null;
+				}
+			};
+			oc.change(getConfigAndSignListener(dataId, listener));
+			listeners
+			.getOrDefault(dataId, new ArrayList<>())
+			.add(listener);
+		}catch (Exception e) {
+		}
+	}
+	protected static interface ErrorAction{
+		public void act(Object o);
+	}
+	protected static interface OnChange{
+		public void change(String changeData);
+	}
+}

--- a/soul-web/src/main/java/org/dromara/soul/web/cache/NacosSyncCache.java
+++ b/soul-web/src/main/java/org/dromara/soul/web/cache/NacosSyncCache.java
@@ -1,0 +1,39 @@
+package org.dromara.soul.web.cache;
+
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.boot.CommandLineRunner;
+
+import com.alibaba.nacos.api.config.ConfigService;
+import com.google.gson.Gson;
+
+/**
+ * NacosSyncCache
+ * 
+ * @author Chenxj
+ * @date 2020年3月12日-下午1:49:55
+ */
+public class NacosSyncCache extends NacosCacheHandler implements CommandLineRunner, DisposableBean {
+
+	public NacosSyncCache(final ConfigService configService) {
+		super(configService);
+	}
+
+	@Override
+	public void run(String... args) throws Exception {
+		Gson gson=new Gson();
+		watcherData(authDataId,changeData->updateAuthMap(gson, changeData, e->publishConfig(gson, authDataId, AUTH_MAP)));
+		watcherData(pluginDataId, changeData->updatePluginMap(gson, changeData, e->publishConfig(gson, pluginDataId, PLUGIN_MAP)));
+		watcherData(selectorDataId, changeData->updateSelectorMap(gson, changeData, e->publishConfig(gson, selectorDataId, SELECTOR_MAP)));
+		watcherData(metaDataId, changeData->updateMetaDataMap(gson, changeData, e->publishConfig(gson, metaDataId, META_DATA)));
+		watcherData(ruleDataId, changeData->updateRuleMap(gson, changeData, e->publishConfig(gson, ruleDataId, RULE_MAP)));
+	}
+	
+	@Override
+	public void destroy() throws Exception {
+		listeners.forEach((dataId,lss)->{
+			lss.stream().forEach(listener->configService.removeListener(dataId, group, listener));
+			lss.clear();
+		});
+		listeners.clear();
+	}
+}

--- a/soul-web/src/main/java/org/dromara/soul/web/configuration/LocalCacheConfiguration.java
+++ b/soul-web/src/main/java/org/dromara/soul/web/configuration/LocalCacheConfiguration.java
@@ -22,9 +22,11 @@ import org.dromara.soul.common.dto.AppAuthData;
 import org.dromara.soul.common.dto.PluginData;
 import org.dromara.soul.common.dto.RuleData;
 import org.dromara.soul.common.dto.SelectorData;
+import org.dromara.soul.configuration.nacos.NacosConfiguration;
 import org.dromara.soul.configuration.zookeeper.ZookeeperConfiguration;
 import org.dromara.soul.web.cache.HttpLongPollSyncCache;
 import org.dromara.soul.web.cache.LocalCacheManager;
+import org.dromara.soul.web.cache.NacosSyncCache;
 import org.dromara.soul.web.cache.WebsocketSyncCache;
 import org.dromara.soul.web.cache.ZookeeperSyncCache;
 import org.dromara.soul.web.config.SoulConfig;
@@ -35,6 +37,8 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+
+import com.alibaba.nacos.api.config.ConfigService;
 
 /**
  * Automatic data cache configuration for caching {@link AppAuthData}、{@link PluginData}、{@link RuleData}、{@link SelectorData}.
@@ -65,6 +69,30 @@ public class LocalCacheConfiguration {
         public LocalCacheManager localCacheManager(final ZkClient zkClient) {
             return new ZookeeperSyncCache(zkClient);
         }
+    }
+    /**
+     * The type Nacos.
+     * 
+     * @author Chenxj
+     * @date 2020年3月12日-下午2:33:30
+     */
+    @Configuration
+    @ConditionalOnMissingBean(LocalCacheManager.class)
+    @ConditionalOnProperty(name = "soul.sync.strategy", havingValue = "nacos")
+    @Import(NacosConfiguration.class)
+    static class NacosCacheManager{
+    	/**
+    	 * Nacos cache manager local cache manager.
+    	 * 
+    	 * @author chenxj
+    	 * @date 2020年3月12日 下午2:35:32
+    	 * @param configService the nacos config service
+    	 * @return the local cache manager
+    	 */
+    	@Bean
+        public LocalCacheManager localCacheManager(final ConfigService configService) {
+    		return new NacosSyncCache(configService);
+    	}
     }
 
     /**

--- a/soul-web/src/main/java/org/dromara/soul/web/filter/DubboBodyWebFilter.java
+++ b/soul-web/src/main/java/org/dromara/soul/web/filter/DubboBodyWebFilter.java
@@ -52,6 +52,7 @@ public class DubboBodyWebFilter implements WebFilter {
         if (Objects.nonNull(requestDTO) && RpcTypeEnum.DUBBO.getName().equals(requestDTO.getRpcType())) {
             MediaType mediaType = request.getHeaders().getContentType();
             ServerRequest serverRequest = ServerRequest.create(exchange, messageReaders);
+            //此处转换有问题，当请求body为空字符串时不报错，也不给错误提示，亦无法进入dubbo插件
             return serverRequest.bodyToMono(String.class)
                     .flatMap(body -> {
                         if (MediaType.APPLICATION_JSON.isCompatibleWith(mediaType)) {

--- a/soul-web/src/main/java/org/dromara/soul/web/spring/SoulPluginBeanPostProcessor.java
+++ b/soul-web/src/main/java/org/dromara/soul/web/spring/SoulPluginBeanPostProcessor.java
@@ -1,0 +1,27 @@
+package org.dromara.soul.web.spring;
+
+import org.dromara.soul.web.plugin.SoulPlugin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.stereotype.Component;
+
+/**
+ * SoulPluginBeanPostProcessor
+ * 
+ * @author Chenxj
+ * @date 2020年3月13日-下午4:59:09
+ */
+@Component
+public class SoulPluginBeanPostProcessor implements BeanPostProcessor{
+	private Logger log=LoggerFactory.getLogger(getClass());
+	@Override
+	public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+		if(bean instanceof SoulPlugin) {
+			SoulPlugin sp=(SoulPlugin)bean;
+			log.info("find pluging:[{}]\t[ {} ]",sp.named(),sp.getClass().getName());
+		}
+		return bean;
+	}
+}


### PR DESCRIPTION
1.配置中心支持Nacos和阿里云ACM
2.移除数据库初始化时写死的soul数据库名称，防止误修改原有数据库数据，库名以连接时数据库为准
3.解决metaData无法修改path问题
4.metaData添加id，用于去重