### PR TITLE
fix DubboPlugin

### DIFF
--- a/soul-web/src/main/java/org/dromara/soul/web/configuration/DubboConfiguration.java
+++ b/soul-web/src/main/java/org/dromara/soul/web/configuration/DubboConfiguration.java
@@ -26,6 +26,7 @@ import org.dromara.soul.web.plugin.dubbo.DefaultGenericParamResolveServiceImpl;
 import org.dromara.soul.web.plugin.dubbo.DubboProxyService;
 import org.dromara.soul.web.plugin.dubbo.GenericParamResolveService;
 import org.dromara.soul.web.plugin.function.DubboPlugin;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.SearchStrategy;
@@ -69,8 +70,8 @@ public class DubboConfiguration {
      * @return {@linkplain DubboPlugin}
      */
     @Bean
-    public SoulPlugin dubboPlugin(@Qualifier("localCacheManager") final LocalCacheManager localCacheManager) {
-        return new DubboPlugin(localCacheManager, new DubboProxyService(genericParamResolveService()));
+    public SoulPlugin dubboPlugin(@Qualifier("localCacheManager") final LocalCacheManager localCacheManager, @Autowired final GenericParamResolveService genericParamResolveService) {
+        return new DubboPlugin(localCacheManager, new DubboProxyService(genericParamResolveService));
     }
 
     /**


### PR DESCRIPTION
虽然有GenericParamResolveService接口，但是实现后依然是无效的，因为SoulPlugin dubboPlugin bean是写死的。