### PR TITLE
fix exception when dubbo has no params

### DIFF
--- a/soul-bootstrap/src/main/java/org/dromara/soul/bootstrap/dubbo/DubboMultiParameterResolveServiceImpl.java
+++ b/soul-bootstrap/src/main/java/org/dromara/soul/bootstrap/dubbo/DubboMultiParameterResolveServiceImpl.java
@@ -20,6 +20,7 @@
 package org.dromara.soul.bootstrap.dubbo;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Strings;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.dromara.soul.web.plugin.dubbo.GenericParamResolveService;
@@ -65,7 +66,7 @@ public class DubboMultiParameterResolveServiceImpl implements GenericParamResolv
     }
 
     private static String[] splitParameterTypes(String parameterTypes) {
-        if (parameterTypes.length() == 0) {
+        if (Strings.isNullOrEmpty(parameterTypes)) {
             return new String[0];
         }
         List<String> ls = new ArrayList<>();


### PR DESCRIPTION
```plaintext
java.lang.NullPointerException: null
	at org.dromara.soul.bootstrap.dubbo.DubboMultiParameterResolveServiceImpl.splitParameterTypes(DubboMultiParameterResolveServiceImpl.java:68)
	Suppressed: reactor.core.publisher.FluxOnAssembly$OnAssemblyException:
Error has been observed at the following site(s):
	|_ checkpoint ⇢ org.dromara.soul.web.configuration.ErrorHandlerConfiguration$1 [DefaultWebFilterChain]
	|_ checkpoint ⇢ org.dromara.soul.web.filter.DubboBodyWebFilter [DefaultWebFilterChain]
	|_ checkpoint ⇢ org.dromara.soul.web.filter.WebSocketWebFilter [DefaultWebFilterChain]
	|_ checkpoint ⇢ org.dromara.soul.web.filter.ParamWebFilter [DefaultWebFilterChain]
	|_ checkpoint ⇢ org.dromara.soul.web.filter.FileSizeFilter [DefaultWebFilterChain]
	|_ checkpoint ⇢ org.dromara.soul.bootstrap.cors.HealthFilter [DefaultWebFilterChain]
	|_ checkpoint ⇢ org.dromara.soul.bootstrap.cors.CrossFilter [DefaultWebFilterChain]
	|_ checkpoint ⇢ org.springframework.boot.actuate.metrics.web.reactive.server.MetricsWebFilter [DefaultWebFilterChain]
	|_ checkpoint ⇢ HTTP GET "/xxx" [ExceptionHandlingWebHandler]
Stack trace:
		at org.dromara.soul.bootstrap.dubbo.DubboMultiParameterResolveServiceImpl.splitParameterTypes(DubboMultiParameterResolveServiceImpl.java:68)
		at org.dromara.soul.bootstrap.dubbo.DubboMultiParameterResolveServiceImpl.buildParameter(DubboMultiParameterResolveServiceImpl.java:50)
		at org.dromara.soul.web.plugin.dubbo.DubboProxyService.genericInvoker(DubboProxyService.java:92)
		at org.dromara.soul.web.plugin.function.DubboPlugin.doExecute(DubboPlugin.java:66)
		at org.dromara.soul.web.plugin.AbstractSoulPlugin.execute(AbstractSoulPlugin.java:109)
		at org.dromara.soul.web.handler.SoulWebHandler$DefaultSoulPluginChain.lambda$execute$0(SoulWebHandler.java:104)
		at reactor.core.publisher.MonoDefer.subscribe(MonoDefer.java:44)
		at reactor.core.publisher.MonoDefer.subscribe(MonoDefer.java:52)
		at reactor.core.publisher.MonoDefer.subscribe(MonoDefer.java:52)
		at reactor.core.publisher.MonoDefer.subscribe(MonoDefer.java:52)
		at reactor.core.publisher.MonoDefer.subscribe(MonoDefer.java:52)
		at reactor.core.publisher.MonoDefer.subscribe(MonoDefer.java:52)
		at reactor.core.publisher.MonoDefer.subscribe(MonoDefer.java:52)
		at reactor.core.publisher.MonoDefer.subscribe(MonoDefer.java:52)
		at reactor.core.publisher.MonoDefer.subscribe(MonoDefer.java:52)
		at reactor.core.publisher.MonoDefer.subscribe(MonoDefer.java:52)
		at reactor.core.publisher.Mono.subscribe(Mono.java:4105)
		at reactor.core.publisher.MonoSubscribeOn$SubscribeOnSubscriber.run(MonoSubscribeOn.java:124)
		at reactor.core.scheduler.WorkerTask.call(WorkerTask.java:84)
		at reactor.core.scheduler.WorkerTask.call(WorkerTask.java:37)
		at java.util.concurrent.FutureTask.run$$$capture(FutureTask.java:266)
		at java.util.concurrent.FutureTask.run(FutureTask.java)
		at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
		at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
		at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
		at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
		at java.lang.Thread.run(Thread.java:748)

```