### PR TITLE
springmvc 中有 full扫描整个服务的功能，springcloud中没有，我复刻过来的

### DIFF
--- a/soul-client/soul-client-http/soul-client-springcloud/src/main/java/org/dromara/soul/client/springcloud/config/SoulSpringCloudConfig.java
+++ b/soul-client/soul-client-http/soul-client-springcloud/src/main/java/org/dromara/soul/client/springcloud/config/SoulSpringCloudConfig.java
@@ -30,4 +30,9 @@ public class SoulSpringCloudConfig {
     private String adminUrl;
     
     private String contextPath;
+
+    /**
+     * 如果配置了full为true 代表代理整个服务.
+     */
+    private boolean full;
 }

--- a/soul-client/soul-client-http/soul-client-springcloud/src/main/java/org/dromara/soul/client/springcloud/init/ContextRegisterListener.java
+++ b/soul-client/soul-client-http/soul-client-springcloud/src/main/java/org/dromara/soul/client/springcloud/init/ContextRegisterListener.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dromara.soul.client.springcloud.init;
+
+import lombok.extern.slf4j.Slf4j;
+import org.dromara.soul.client.common.utils.OkHttpTools;
+import org.dromara.soul.client.springcloud.config.SoulSpringCloudConfig;
+import org.dromara.soul.client.springcloud.dto.SpringCloudRegisterDTO;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.core.env.Environment;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * The type Context register listener.
+ * @author tnnn
+ */
+@Slf4j
+public class ContextRegisterListener implements ApplicationListener<ContextRefreshedEvent> {
+
+    private volatile AtomicBoolean registered = new AtomicBoolean(false);
+
+    private final String url;
+
+    private final SoulSpringCloudConfig config;
+
+    private final Environment env;
+
+    /**
+     * Instantiates a new Context register listener.
+     *
+     * @param config the soul spring cloud config
+     * @param env    the env
+     */
+    public ContextRegisterListener(final SoulSpringCloudConfig config, final Environment env) {
+        String contextPath = config.getContextPath();
+        String adminUrl = config.getAdminUrl();
+        String appName = env.getProperty("spring.application.name");
+        if (contextPath == null || "".equals(contextPath)
+                || adminUrl == null || "".equals(adminUrl)
+                || appName == null || "".equals(appName)) {
+            throw new RuntimeException("spring cloud param must config the contextPath, adminUrl and appName");
+        }
+        this.config = config;
+        this.env = env;
+        this.url = adminUrl + "/soul-client/springcloud-register";
+    }
+
+    @Override
+    public void onApplicationEvent(final ContextRefreshedEvent contextRefreshedEvent) {
+        if (!registered.compareAndSet(false, true)) {
+            return;
+        }
+        if (config.isFull()) {
+            post(buildJsonParams(config.getContextPath()));
+        }
+    }
+
+    private void post(final String json) {
+        try {
+            String result = OkHttpTools.getInstance().post(url, json);
+            if (Objects.equals(result, "success")) {
+                log.info("http context register success :{} ", json);
+            } else {
+                log.error("http context register error :{} ", json);
+            }
+        } catch (IOException e) {
+            log.error("cannot register soul admin param :{}", url + ":" + json);
+        }
+    }
+
+    private String buildJsonParams(final String contextPath) {
+
+        String appName = env.getProperty("spring.application.name");
+        String path = contextPath + "/**";
+        SpringCloudRegisterDTO registerDTO = SpringCloudRegisterDTO.builder()
+                .context(contextPath)
+                .appName(appName)
+                .path(path)
+                .rpcType("springCloud")
+                .enabled(true)
+                .ruleName(path)
+                .build();
+        return OkHttpTools.getInstance().getGosn().toJson(registerDTO);
+    }
+}

--- a/soul-client/soul-client-http/soul-client-springcloud/src/main/java/org/dromara/soul/client/springcloud/init/SpringCloudClientBeanPostProcessor.java
+++ b/soul-client/soul-client-http/soul-client-springcloud/src/main/java/org/dromara/soul/client/springcloud/init/SpringCloudClientBeanPostProcessor.java
@@ -77,6 +77,9 @@ public class SpringCloudClientBeanPostProcessor implements BeanPostProcessor {
 
     @Override
     public Object postProcessAfterInitialization(@NonNull final Object bean, @NonNull final String beanName) throws BeansException {
+        if (config.isFull()) {
+            return bean;
+        }
         Controller controller = AnnotationUtils.findAnnotation(bean.getClass(), Controller.class);
         RestController restController = AnnotationUtils.findAnnotation(bean.getClass(), RestController.class);
         RequestMapping requestMapping = AnnotationUtils.findAnnotation(bean.getClass(), RequestMapping.class);

--- a/soul-spring-boot-starter/soul-spring-boot-starter-client/soul-spring-boot-starter-client-springcloud/src/main/java/org/dromara/soul/springboot/starter/client/springcloud/SoulSpringCloudClientConfiguration.java
+++ b/soul-spring-boot-starter/soul-spring-boot-starter-client/soul-spring-boot-starter-client-springcloud/src/main/java/org/dromara/soul/springboot/starter/client/springcloud/SoulSpringCloudClientConfiguration.java
@@ -18,6 +18,7 @@
 package org.dromara.soul.springboot.starter.client.springcloud;
 
 import org.dromara.soul.client.springcloud.config.SoulSpringCloudConfig;
+import org.dromara.soul.client.springcloud.init.ContextRegisterListener;
 import org.dromara.soul.client.springcloud.init.SpringCloudClientBeanPostProcessor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -42,6 +43,18 @@ public class SoulSpringCloudClientConfiguration {
     @Bean
     public SpringCloudClientBeanPostProcessor springCloudClientBeanPostProcessor(final SoulSpringCloudConfig soulSpringCloudConfig, final Environment env) {
         return new SpringCloudClientBeanPostProcessor(soulSpringCloudConfig, env);
+    }
+
+    /**
+     * Context register listener context register listener.
+     *
+     * @param soulSpringCloudConfig the soul spring cloud config
+     * @param env                   the env
+     * @return the context register listener
+     */
+    @Bean
+    public ContextRegisterListener contextRegisterListener(final SoulSpringCloudConfig soulSpringCloudConfig, final Environment env) {
+        return new ContextRegisterListener(soulSpringCloudConfig, env);
     }
     
     /**


### PR DESCRIPTION
```java
mvn clean install  ： [INFO] BUILD SUCCESS
```
## 测试 soul-demo-springboot-7   full: true
```yaml
soul:
  springcloud:
    admin-url: http://localhost:9095
    context-path: /sb-demo7-api
    full: true
```
```xml
2020-12-01 14:18:17.215  INFO 2964 --- [           main] o.d.s.c.s.init.ContextRegisterListener   : http context register success :{"appName":"sb-demo7-service","context":"/sb-demo7-api","path":"/sb-demo7-api/**","rpcType":"springCloud","ruleName":"/sb-demo7-api/**","enabled":true} 
```
![image](https://user-images.githubusercontent.com/45027672/100706149-75b01980-33e3-11eb-91c9-38f432ebd702.png)

## 测试 soul-demo-springboot-6   原先模式
```yaml
soul:
  springcloud:
    admin-url: http://localhost:9095
    context-path: /sb-demo6-api
```
```xml
2020-12-01 14:21:24.470  INFO 2200 --- [pool-1-thread-1] c.s.i.SpringCloudClientBeanPostProcessor : http client register success :{"appName":"sb-demo6-service","context":"/sb-demo6-api","path":"/sb-demo6-api/user/**","pathDesc":"","rpcType":"springCloud","ruleName":"/sb-demo6-api/user/**","enabled":true} 
```
![image](https://user-images.githubusercontent.com/45027672/100706257-a5f7b800-33e3-11eb-8c3b-1204fa312c77.png)

## 测试发现没有影响原先功能
