### PR TITLE
optimize the test code in soul-sync-data-center

### DIFF
--- a/soul-sync-data-center/soul-sync-data-http/src/test/java/org/dromara/soul/sync/data/http/HttpSyncDataServiceTest.java
+++ b/soul-sync-data-center/soul-sync-data-http/src/test/java/org/dromara/soul/sync/data/http/HttpSyncDataServiceTest.java
@@ -53,12 +53,6 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-/**
- * Test cases for {@link HttpSyncDataService}.
- *
- * @author davidliu
- * @author dengliming
- */
 @RunWith(MockitoJUnitRunner.class)
 public class HttpSyncDataServiceTest {
 

--- a/soul-sync-data-center/soul-sync-data-http/src/test/java/org/dromara/soul/sync/data/http/refresh/AppAuthDataRefreshTest.java
+++ b/soul-sync-data-center/soul-sync-data-http/src/test/java/org/dromara/soul/sync/data/http/refresh/AppAuthDataRefreshTest.java
@@ -30,46 +30,30 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-/**
- * Test cases for {@link AppAuthDataRefresh}.
- *
- * @author davidliu
- */
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 public class AppAuthDataRefreshTest {
-    
+
     private final AppAuthDataRefresh mockAppAuthDataRefresh = this.buildMockAppAuthDataRefresh();
-    
-    /**
-     * test case for {@link AppAuthDataRefresh#convert(JsonObject)}.
-     */
+
     @Test
     public void testConvert() {
         JsonObject jsonObject = new JsonObject();
         JsonObject expectJsonObject = new JsonObject();
         jsonObject.add(ConfigGroupEnum.APP_AUTH.name(), expectJsonObject);
-        Assert.assertEquals(expectJsonObject, mockAppAuthDataRefresh.convert(jsonObject));
+        assertThat(mockAppAuthDataRefresh.convert(jsonObject), is(expectJsonObject));
     }
-    
-    /**
-     * test case for {@link AppAuthDataRefresh#fromJson(JsonObject)}.
-     */
+
     @Test
     public void testFromJson() {
         ConfigData<AppAuthData> appAuthDataConfigData = new ConfigData<>();
         AppAuthData appAuthData = new AppAuthData();
         appAuthDataConfigData.setData(Collections.singletonList(appAuthData));
         JsonObject jsonObject = GsonUtils.getGson().fromJson(GsonUtils.getGson().toJson(appAuthDataConfigData), JsonObject.class);
-        Assert.assertEquals(appAuthDataConfigData, mockAppAuthDataRefresh.fromJson(jsonObject));
+        assertThat(mockAppAuthDataRefresh.fromJson(jsonObject), is(appAuthDataConfigData));
     }
-    
-    /**
-     * This case coverages the following method:
-     * {@link AppAuthDataRefresh#cacheConfigData()}
-     * {@link AppAuthDataRefresh#updateCacheIfNeed(ConfigData)}.
-     * For {@link SelectorDataRefresh} inherits from {@link AbstractDataRefresh}, the {@link AbstractDataRefresh#GROUP_CACHE} was initialized when the class of
-     * {@link AbstractDataRefresh} load, in two different test methods in this class, the the {@link AbstractDataRefresh#GROUP_CACHE} class only load once, so
-     * the method which manipulate the {@link AbstractDataRefresh#GROUP_CACHE} invocation has aftereffects to the other methods.
-     */
+
     @Test
     public void testUpdateCacheIfNeed() {
         final AppAuthDataRefresh appAuthDataRefresh = mockAppAuthDataRefresh;
@@ -77,12 +61,9 @@ public class AppAuthDataRefreshTest {
         ConfigData<AppAuthData> expect = new ConfigData<>();
         expect.setLastModifyTime(System.currentTimeMillis());
         appAuthDataRefresh.updateCacheIfNeed(expect);
-        Assert.assertEquals(expect, appAuthDataRefresh.cacheConfigData());
+        Assert.assertThat(appAuthDataRefresh.cacheConfigData(), is(expect));
     }
-    
-    /**
-     * This case is only for {@link AppAuthDataRefresh} code coverage.
-     */
+
     @Test
     public void testRefreshCoverage() {
         final AppAuthDataRefresh appAuthDataRefresh = mockAppAuthDataRefresh;
@@ -91,23 +72,21 @@ public class AppAuthDataRefreshTest {
         appAuthDataRefresh.refresh(appAuthDataList);
         appAuthDataList.add(appAuthData);
         appAuthDataRefresh.refresh(appAuthDataList);
-        
     }
-    
+
     private AppAuthDataRefresh buildMockAppAuthDataRefresh() {
         List<AuthDataSubscriber> authDataSubscribers = new ArrayList<>();
         authDataSubscribers.add(new AuthDataSubscriber() {
             @Override
             public void onSubscribe(final AppAuthData appAuthData) {
-            
+
             }
-            
+
             @Override
             public void unSubscribe(final AppAuthData appAuthData) {
-            
+
             }
         });
         return new AppAuthDataRefresh(authDataSubscribers);
     }
-    
 }

--- a/soul-sync-data-center/soul-sync-data-http/src/test/java/org/dromara/soul/sync/data/http/refresh/AppAuthDataRefreshTest.java
+++ b/soul-sync-data-center/soul-sync-data-http/src/test/java/org/dromara/soul/sync/data/http/refresh/AppAuthDataRefreshTest.java
@@ -23,7 +23,6 @@ import org.dromara.soul.common.dto.ConfigData;
 import org.dromara.soul.common.enums.ConfigGroupEnum;
 import org.dromara.soul.common.utils.GsonUtils;
 import org.dromara.soul.sync.data.api.AuthDataSubscriber;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -61,7 +60,7 @@ public class AppAuthDataRefreshTest {
         ConfigData<AppAuthData> expect = new ConfigData<>();
         expect.setLastModifyTime(System.currentTimeMillis());
         appAuthDataRefresh.updateCacheIfNeed(expect);
-        Assert.assertThat(appAuthDataRefresh.cacheConfigData(), is(expect));
+        assertThat(appAuthDataRefresh.cacheConfigData(), is(expect));
     }
 
     @Test

--- a/soul-sync-data-center/soul-sync-data-http/src/test/java/org/dromara/soul/sync/data/http/refresh/MetaDataRefreshTest.java
+++ b/soul-sync-data-center/soul-sync-data-http/src/test/java/org/dromara/soul/sync/data/http/refresh/MetaDataRefreshTest.java
@@ -32,7 +32,7 @@ import java.util.List;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
-public class MetaDataRefreshTest {
+public final class MetaDataRefreshTest {
 
     private final MetaDataRefresh mockMetaDataRefresh = this.buildMockMetaDataRefresh();
 

--- a/soul-sync-data-center/soul-sync-data-http/src/test/java/org/dromara/soul/sync/data/http/refresh/MetaDataRefreshTest.java
+++ b/soul-sync-data-center/soul-sync-data-http/src/test/java/org/dromara/soul/sync/data/http/refresh/MetaDataRefreshTest.java
@@ -23,53 +23,36 @@ import org.dromara.soul.common.dto.MetaData;
 import org.dromara.soul.common.enums.ConfigGroupEnum;
 import org.dromara.soul.common.utils.GsonUtils;
 import org.dromara.soul.sync.data.api.MetaDataSubscriber;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-/**
- * Test cases for {@link MetaDataRefresh}.
- *
- * @author davidliu
- */
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 public class MetaDataRefreshTest {
-    
+
     private final MetaDataRefresh mockMetaDataRefresh = this.buildMockMetaDataRefresh();
-    
-    /**
-     * test case for {@link MetaDataRefresh#convert(JsonObject)}.
-     */
+
     @Test
     public void testConvert() {
         JsonObject jsonObject = new JsonObject();
         JsonObject expectJsonObject = new JsonObject();
         jsonObject.add(ConfigGroupEnum.META_DATA.name(), expectJsonObject);
-        Assert.assertEquals(expectJsonObject, mockMetaDataRefresh.convert(jsonObject));
+        assertThat(mockMetaDataRefresh.convert(jsonObject), is(expectJsonObject));
     }
-    
-    /**
-     * test case for {@link MetaDataRefresh#fromJson(JsonObject)}.
-     */
+
     @Test
     public void testFromJson() {
         ConfigData<MetaData> metaDataConfigData = new ConfigData<>();
         MetaData metaData = new MetaData();
         metaDataConfigData.setData(Collections.singletonList(metaData));
         JsonObject jsonObject = GsonUtils.getGson().fromJson(GsonUtils.getGson().toJson(metaDataConfigData), JsonObject.class);
-        Assert.assertEquals(metaDataConfigData, mockMetaDataRefresh.fromJson(jsonObject));
+        assertThat(mockMetaDataRefresh.fromJson(jsonObject), is(metaDataConfigData));
     }
-    
-    /**
-     * This case coverages the following method:
-     * {@link MetaDataRefresh#cacheConfigData()}
-     * {@link MetaDataRefresh#updateCacheIfNeed(ConfigData)}.
-     * For {@link SelectorDataRefresh} inherits from {@link AbstractDataRefresh}, the {@link AbstractDataRefresh#GROUP_CACHE} was initialized when the class of
-     * {@link AbstractDataRefresh} load, in two different test methods in this class, the the {@link AbstractDataRefresh#GROUP_CACHE} class only load once, so
-     * the method which manipulate the {@link AbstractDataRefresh#GROUP_CACHE} invocation has aftereffects to the other methods.
-     */
+
     @Test
     public void testUpdateCacheIfNeed() {
         final MetaDataRefresh metaDataRefresh = mockMetaDataRefresh;
@@ -77,12 +60,9 @@ public class MetaDataRefreshTest {
         ConfigData<MetaData> expect = new ConfigData<>();
         expect.setLastModifyTime(System.currentTimeMillis());
         metaDataRefresh.updateCacheIfNeed(expect);
-        Assert.assertEquals(expect, metaDataRefresh.cacheConfigData());
+        assertThat(metaDataRefresh.cacheConfigData(), is(expect));
     }
-    
-    /**
-     * This case is only for {@link MetaDataRefresh} code coverage.
-     */
+
     @Test
     public void testRefreshCoverage() {
         final MetaDataRefresh metaDataRefresh = mockMetaDataRefresh;
@@ -91,23 +71,21 @@ public class MetaDataRefreshTest {
         metaDataRefresh.refresh(metaDataList);
         metaDataList.add(metaData);
         metaDataRefresh.refresh(metaDataList);
-        
     }
-    
+
     private MetaDataRefresh buildMockMetaDataRefresh() {
         List<MetaDataSubscriber> metaDataSubscribers = new ArrayList<>();
         metaDataSubscribers.add(new MetaDataSubscriber() {
             @Override
             public void onSubscribe(final MetaData metaData) {
-            
+
             }
-            
+
             @Override
             public void unSubscribe(final MetaData metaData) {
-            
+
             }
         });
         return new MetaDataRefresh(metaDataSubscribers);
     }
-    
 }

--- a/soul-sync-data-center/soul-sync-data-http/src/test/java/org/dromara/soul/sync/data/http/refresh/PluginDataRefreshTest.java
+++ b/soul-sync-data-center/soul-sync-data-http/src/test/java/org/dromara/soul/sync/data/http/refresh/PluginDataRefreshTest.java
@@ -23,58 +23,41 @@ import org.dromara.soul.common.dto.PluginData;
 import org.dromara.soul.common.enums.ConfigGroupEnum;
 import org.dromara.soul.common.utils.GsonUtils;
 import org.dromara.soul.sync.data.api.PluginDataSubscriber;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-/**
- * Test cases for {@link PluginDataRefresh}.
- *
- * @author davidliu
- */
 public class PluginDataRefreshTest {
-    
+
     private final PluginDataRefresh mockPluginDataRefresh = new PluginDataRefresh(new PluginDataSubscriber() {
         @Override
         public void onSubscribe(final PluginData pluginData) {
-        
+
         }
     });
-    
-    /**
-     * test case for {@link PluginDataRefresh#convert(JsonObject)}.
-     */
+
     @Test
     public void testConvert() {
         JsonObject jsonObject = new JsonObject();
         JsonObject expectJsonObject = new JsonObject();
         jsonObject.add(ConfigGroupEnum.PLUGIN.name(), expectJsonObject);
-        Assert.assertEquals(expectJsonObject, mockPluginDataRefresh.convert(jsonObject));
+        assertThat(mockPluginDataRefresh.convert(jsonObject), is(expectJsonObject));
     }
-    
-    /**
-     * test case for {@link PluginDataRefresh#fromJson(JsonObject)}.
-     */
+
     @Test
     public void testFromJson() {
         ConfigData<PluginData> pluginDataConfigData = new ConfigData<>();
         PluginData pluginData = new PluginData();
         pluginDataConfigData.setData(Collections.singletonList(pluginData));
         JsonObject jsonObject = GsonUtils.getGson().fromJson(GsonUtils.getGson().toJson(pluginDataConfigData), JsonObject.class);
-        Assert.assertEquals(pluginDataConfigData, mockPluginDataRefresh.fromJson(jsonObject));
+        assertThat(mockPluginDataRefresh.fromJson(jsonObject), is(pluginDataConfigData));
     }
-    
-    /**
-     * This case coverages the following method:
-     * {@link PluginDataRefresh#cacheConfigData()}
-     * {@link PluginDataRefresh#updateCacheIfNeed(ConfigData)}.
-     * For {@link SelectorDataRefresh} inherits from {@link AbstractDataRefresh}, the {@link AbstractDataRefresh#GROUP_CACHE} was initialized when the class of
-     * {@link AbstractDataRefresh} load, in two different test methods in this class, the the {@link AbstractDataRefresh#GROUP_CACHE} class only load once, so
-     * the method which manipulate the {@link AbstractDataRefresh#GROUP_CACHE} invocation has aftereffects to the other methods
-     */
+
     @Test
     public void testUpdateCacheIfNeed() {
         final PluginDataRefresh pluginDataRefresh = mockPluginDataRefresh;
@@ -82,12 +65,9 @@ public class PluginDataRefreshTest {
         ConfigData<PluginData> expect = new ConfigData<>();
         expect.setLastModifyTime(System.currentTimeMillis());
         pluginDataRefresh.updateCacheIfNeed(expect);
-        Assert.assertEquals(expect, pluginDataRefresh.cacheConfigData());
+        assertThat(pluginDataRefresh.cacheConfigData(), is(expect));
     }
-    
-    /**
-     * This case is only for {@link PluginDataRefresh} code coverage.
-     */
+
     @Test
     public void testRefreshCoverage() {
         final PluginDataRefresh pluginDataRefresh = mockPluginDataRefresh;
@@ -96,6 +76,5 @@ public class PluginDataRefreshTest {
         pluginDataRefresh.refresh(selectorDataList);
         selectorDataList.add(selectorData);
         pluginDataRefresh.refresh(selectorDataList);
-        
     }
 }

--- a/soul-sync-data-center/soul-sync-data-http/src/test/java/org/dromara/soul/sync/data/http/refresh/PluginDataRefreshTest.java
+++ b/soul-sync-data-center/soul-sync-data-http/src/test/java/org/dromara/soul/sync/data/http/refresh/PluginDataRefreshTest.java
@@ -32,7 +32,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public class PluginDataRefreshTest {
+public final class PluginDataRefreshTest {
 
     private final PluginDataRefresh mockPluginDataRefresh = new PluginDataRefresh(new PluginDataSubscriber() {
         @Override

--- a/soul-sync-data-center/soul-sync-data-http/src/test/java/org/dromara/soul/sync/data/http/refresh/RuleDataRefreshTest.java
+++ b/soul-sync-data-center/soul-sync-data-http/src/test/java/org/dromara/soul/sync/data/http/refresh/RuleDataRefreshTest.java
@@ -24,58 +24,41 @@ import org.dromara.soul.common.dto.RuleData;
 import org.dromara.soul.common.enums.ConfigGroupEnum;
 import org.dromara.soul.common.utils.GsonUtils;
 import org.dromara.soul.sync.data.api.PluginDataSubscriber;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-/**
- * Test cases for {@link RuleDataRefresh}.
- *
- * @author davidliu
- */
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 public class RuleDataRefreshTest {
-    
+
     private final RuleDataRefresh mockRuleDataRefresh = new RuleDataRefresh(new PluginDataSubscriber() {
         @Override
         public void onSubscribe(final PluginData pluginData) {
-        
+
         }
     });
-    
-    /**
-     * test case for {@link RuleDataRefresh#convert(JsonObject)}.
-     */
+
     @Test
     public void testConvert() {
         JsonObject jsonObject = new JsonObject();
         JsonObject expectJsonObject = new JsonObject();
         jsonObject.add(ConfigGroupEnum.RULE.name(), expectJsonObject);
-        Assert.assertEquals(expectJsonObject, mockRuleDataRefresh.convert(jsonObject));
+        assertThat(mockRuleDataRefresh.convert(jsonObject), is(expectJsonObject));
     }
-    
-    /**
-     * test case for {@link RuleDataRefresh#fromJson(JsonObject)}.
-     */
+
     @Test
     public void testFromJson() {
         ConfigData<RuleData> ruleDataConfigData = new ConfigData<>();
         RuleData ruleData = new RuleData();
         ruleDataConfigData.setData(Collections.singletonList(ruleData));
         JsonObject jsonObject = GsonUtils.getGson().fromJson(GsonUtils.getGson().toJson(ruleDataConfigData), JsonObject.class);
-        Assert.assertEquals(ruleDataConfigData, mockRuleDataRefresh.fromJson(jsonObject));
+        assertThat(mockRuleDataRefresh.fromJson(jsonObject), is(ruleDataConfigData));
     }
-    
-    /**
-     * This case coverages the following method:
-     * {@link RuleDataRefresh#cacheConfigData()}
-     * {@link RuleDataRefresh#updateCacheIfNeed(ConfigData)}.
-     * For {@link RuleDataRefresh} inherits from {@link AbstractDataRefresh}, the {@link AbstractDataRefresh#GROUP_CACHE} was initialized when the class of
-     * {@link AbstractDataRefresh} load, in two different test methods in this class, the the {@link AbstractDataRefresh#GROUP_CACHE} class only load once, so
-     * the method which manipulate the {@link AbstractDataRefresh#GROUP_CACHE} invocation has aftereffects to the other methods.
-     */
+
     @Test
     public void testUpdateCacheIfNeed() {
         final RuleDataRefresh ruleDataRefresh = mockRuleDataRefresh;
@@ -83,12 +66,9 @@ public class RuleDataRefreshTest {
         ConfigData<RuleData> expect = new ConfigData<>();
         expect.setLastModifyTime(System.currentTimeMillis());
         ruleDataRefresh.updateCacheIfNeed(expect);
-        Assert.assertEquals(expect, ruleDataRefresh.cacheConfigData());
+        assertThat(ruleDataRefresh.cacheConfigData(), is(expect));
     }
-    
-    /**
-     * This case is only for {@link RuleDataRefresh} code coverage.
-     */
+
     @Test
     public void testRefresh() {
         final RuleDataRefresh ruleDataRefresh = mockRuleDataRefresh;
@@ -97,6 +77,5 @@ public class RuleDataRefreshTest {
         ruleDataRefresh.refresh(ruleDataList);
         ruleDataList.add(ruleData);
         ruleDataRefresh.refresh(ruleDataList);
-        
     }
 }

--- a/soul-sync-data-center/soul-sync-data-http/src/test/java/org/dromara/soul/sync/data/http/refresh/SelectorDataRefreshTest.java
+++ b/soul-sync-data-center/soul-sync-data-http/src/test/java/org/dromara/soul/sync/data/http/refresh/SelectorDataRefreshTest.java
@@ -24,59 +24,41 @@ import org.dromara.soul.common.dto.SelectorData;
 import org.dromara.soul.common.enums.ConfigGroupEnum;
 import org.dromara.soul.common.utils.GsonUtils;
 import org.dromara.soul.sync.data.api.PluginDataSubscriber;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-/**
- * Test cases for {@link SelectorDataRefresh}.
- *
- * @author davidliu
- */
 public class SelectorDataRefreshTest {
-    
+
     private final SelectorDataRefresh mockSelectorDataRefresh = new SelectorDataRefresh(new PluginDataSubscriber() {
         @Override
         public void onSubscribe(final PluginData pluginData) {
-        
+
         }
     });
-    
-    
-    /**
-     * test case for {@link SelectorDataRefresh#convert(JsonObject)}.
-     */
+
     @Test
     public void testConvert() {
         JsonObject jsonObject = new JsonObject();
         JsonObject expectJsonObject = new JsonObject();
         jsonObject.add(ConfigGroupEnum.SELECTOR.name(), expectJsonObject);
-        Assert.assertEquals(expectJsonObject, mockSelectorDataRefresh.convert(jsonObject));
+        assertThat(mockSelectorDataRefresh.convert(jsonObject), is(expectJsonObject));
     }
-    
-    /**
-     * test case for {@link SelectorDataRefresh#fromJson(JsonObject)}.
-     */
+
     @Test
     public void testFromJson() {
         ConfigData<SelectorData> selectorDataConfigData = new ConfigData<>();
         SelectorData selectorData = new SelectorData();
         selectorDataConfigData.setData(Collections.singletonList(selectorData));
         JsonObject jsonObject = GsonUtils.getGson().fromJson(GsonUtils.getGson().toJson(selectorDataConfigData), JsonObject.class);
-        Assert.assertEquals(selectorDataConfigData, mockSelectorDataRefresh.fromJson(jsonObject));
+        assertThat(mockSelectorDataRefresh.fromJson(jsonObject), is(selectorDataConfigData));
     }
-    
-    /**
-     * This case coverages the following method:
-     * {@link SelectorDataRefresh#cacheConfigData()}
-     * {@link SelectorDataRefresh#updateCacheIfNeed(ConfigData)}.
-     * For {@link SelectorDataRefresh} inherits from {@link AbstractDataRefresh}, the {@link AbstractDataRefresh#GROUP_CACHE} was initialized when the class of
-     * {@link AbstractDataRefresh} load, in two different test methods in this class, the the {@link AbstractDataRefresh#GROUP_CACHE} class only load once, so
-     * the method which manipulate the {@link AbstractDataRefresh#GROUP_CACHE} invocation has aftereffects to the other methods.
-     */
+
     @Test
     public void testUpdateCacheIfNeed() {
         final SelectorDataRefresh selectorDataRefresh = mockSelectorDataRefresh;
@@ -84,12 +66,9 @@ public class SelectorDataRefreshTest {
         ConfigData<SelectorData> expect = new ConfigData<>();
         expect.setLastModifyTime(System.currentTimeMillis());
         selectorDataRefresh.updateCacheIfNeed(expect);
-        Assert.assertEquals(expect, selectorDataRefresh.cacheConfigData());
+        assertThat(selectorDataRefresh.cacheConfigData(), is(expect));
     }
-    
-    /**
-     * This case is only for {@link SelectorDataRefresh} code coverage.
-     */
+
     @Test
     public void testRefreshCoverage() {
         final SelectorDataRefresh selectorDataRefresh = mockSelectorDataRefresh;
@@ -98,6 +77,5 @@ public class SelectorDataRefreshTest {
         selectorDataRefresh.refresh(selectorDataList);
         selectorDataList.add(selectorData);
         selectorDataRefresh.refresh(selectorDataList);
-        
     }
 }

--- a/soul-sync-data-center/soul-sync-data-nacos/src/test/java/org/dromara/soul/sync/data/nacos/handler/NacosCacheHandlerTest.java
+++ b/soul-sync-data-center/soul-sync-data-nacos/src/test/java/org/dromara/soul/sync/data/nacos/handler/NacosCacheHandlerTest.java
@@ -38,6 +38,7 @@ import org.dromara.soul.sync.data.api.PluginDataSubscriber;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -50,11 +51,6 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.stream.Collectors;
 
-/**
- * Test cases for {@link NacosCacheHandler}.
- *
- * @author kminjava
- */
 @Slf4j
 @SuppressWarnings("all")
 public final class NacosCacheHandlerTest {
@@ -89,13 +85,10 @@ public final class NacosCacheHandlerTest {
     private ConfigService configService;
 
     @Before
-    public void setUp() {
+    public void setup() {
         configService = new NacosMockConfigService();
     }
 
-    /**
-     * test case for {@link NacosCacheHandler#updatePluginMap(String)}.
-     */
     @SneakyThrows
     @Test
     public void testUpdatePluginMap() {
@@ -137,9 +130,6 @@ public final class NacosCacheHandlerTest {
 
     }
 
-    /**
-     * test case for {@link NacosCacheHandler#updateSelectorMap(String)}.
-     */
     @SneakyThrows
     @Test
     public void testUpdateSelectorMap() {
@@ -192,9 +182,6 @@ public final class NacosCacheHandlerTest {
                                         ImmutableList.of(selectorData1))));
     }
 
-    /**
-     * test case for {@link NacosCacheHandler#updateRuleMap(String)}.
-     */
     @SneakyThrows
     @Test
     public void testUpdateRuleMap() {
@@ -242,9 +229,6 @@ public final class NacosCacheHandlerTest {
                                         ImmutableList.of(ruleData1))));
     }
 
-    /**
-     * test case for {@link NacosCacheHandler#updateMetaDataMap(String)}.
-     */
     @SneakyThrows
     @Test
     public void testUpdateMetaDataMap() {
@@ -283,9 +267,6 @@ public final class NacosCacheHandlerTest {
                         .toJson(ImmutableMap.of(metadataPath1, metaData1, metadataPath2, metaData2)));
     }
 
-    /**
-     * test case for {@link NacosCacheHandler#updateAuthMap(String)}.
-     */
     @SneakyThrows
     @Test
     public void testUpdateAuthMap() {
@@ -458,5 +439,4 @@ public final class NacosCacheHandlerTest {
     private void publishConfig(final String dataId, final Object data) {
         configService.publishConfig(dataId, GROUP, GsonUtils.getInstance().toJson(data));
     }
-
 }

--- a/soul-sync-data-center/soul-sync-data-nacos/src/test/java/org/dromara/soul/sync/data/nacos/handler/NacosMockConfigService.java
+++ b/soul-sync-data-center/soul-sync-data-nacos/src/test/java/org/dromara/soul/sync/data/nacos/handler/NacosMockConfigService.java
@@ -19,6 +19,7 @@ package org.dromara.soul.sync.data.nacos.handler;
 
 import com.alibaba.nacos.api.config.ConfigService;
 import com.alibaba.nacos.api.config.listener.Listener;
+
 import java.util.HashMap;
 import java.util.Map;
 

--- a/soul-sync-data-center/soul-sync-data-websocket/src/test/java/org/dromara/soul/plugin/sync/data/weboscket/handler/AuthDataHandlerTest.java
+++ b/soul-sync-data-center/soul-sync-data-websocket/src/test/java/org/dromara/soul/plugin/sync/data/weboscket/handler/AuthDataHandlerTest.java
@@ -23,18 +23,17 @@ import org.dromara.soul.common.dto.AuthParamData;
 import org.dromara.soul.common.dto.AuthPathData;
 import org.dromara.soul.sync.data.api.AuthDataSubscriber;
 import org.junit.Test;
+
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-import static org.junit.Assert.assertEquals;
+
+import static org.hamcrest.core.Is.is;
+
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.junit.Assert.assertThat;
 
-/**
- * Test cases for {@link AuthDataHandler}.
- *
- * @author cocoZwwang
- */
 public final class AuthDataHandlerTest {
 
     private final List<AuthDataSubscriber> authDataSubscribers;
@@ -49,9 +48,6 @@ public final class AuthDataHandlerTest {
         authDataHandler = new AuthDataHandler(authDataSubscribers);
     }
 
-    /**
-     * test case for {@link AuthDataHandler#convert(String)}.
-     */
     @Test
     public void testConvert() {
         AppAuthData appAuthData = createFakerAppAuthDataObjects(1).get(0);
@@ -60,7 +56,7 @@ public final class AuthDataHandlerTest {
         Gson gson = new Gson();
         String json = gson.toJson(sources);
         List<AppAuthData> appAuthDataResults = authDataHandler.convert(json);
-        assertEquals(appAuthData, appAuthDataResults.get(0));
+        assertThat(appAuthDataResults.get(0), is(appAuthData));
     }
 
     private void setAppAuthDataProperties(final AppAuthData appAuthData) {
@@ -77,11 +73,6 @@ public final class AuthDataHandlerTest {
         appAuthData.setPathDataList(authPathDataList);
     }
 
-    /**
-     * test case for {@link AuthDataHandler#doRefresh(List)}.
-     * First,verify that each AuthDataSubscriber bean has called the {@link AuthDataSubscriber#refresh()} method.
-     * then,verify that each AuthDataSubscriber bean has called the {@link AuthDataSubscriber#onSubscribe(AppAuthData)} method.
-     */
     @Test
     public void testDoRefresh() {
         List<AppAuthData> appAuthDataList = createFakerAppAuthDataObjects(3);
@@ -91,10 +82,6 @@ public final class AuthDataHandlerTest {
                 authDataSubscribers.forEach(authDataSubscriber -> verify(authDataSubscriber).onSubscribe(appAuthData)));
     }
 
-    /**
-     * test case for {@link AuthDataHandler#doUpdate(List)}.
-     * verify that each AuthDataSubscriber bean has called the {@link AuthDataSubscriber#onSubscribe(AppAuthData)} method.
-     */
     @Test
     public void testDoUpdate() {
         List<AppAuthData> appAuthDataList = createFakerAppAuthDataObjects(4);
@@ -103,10 +90,6 @@ public final class AuthDataHandlerTest {
                 authDataSubscribers.forEach(authDataSubscriber -> verify(authDataSubscriber).onSubscribe(appAuthData)));
     }
 
-    /**
-     * test case for {@link AuthDataHandler#doDelete(List)}.
-     * verify that each AuthDataSubscriber bean has called the {@link AuthDataSubscriber#unSubscribe(AppAuthData)} method.
-     */
     @Test
     public void testDoDelete() {
         List<AppAuthData> appAuthDataList = createFakerAppAuthDataObjects(3);

--- a/soul-sync-data-center/soul-sync-data-websocket/src/test/java/org/dromara/soul/plugin/sync/data/weboscket/handler/MetaDataHandlerTest.java
+++ b/soul-sync-data-center/soul-sync-data-websocket/src/test/java/org/dromara/soul/plugin/sync/data/weboscket/handler/MetaDataHandlerTest.java
@@ -21,17 +21,15 @@ import com.google.gson.Gson;
 import org.dromara.soul.common.dto.MetaData;
 import org.dromara.soul.sync.data.api.MetaDataSubscriber;
 import org.junit.Test;
+
 import java.util.LinkedList;
 import java.util.List;
-import static org.junit.Assert.assertEquals;
+
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-/**
- * Test cases for {@link MetaDataHandler}.
- *
- * @author cocoZwwang
- */
 public final class MetaDataHandlerTest {
 
     private final List<MetaDataSubscriber> subscribers;
@@ -46,9 +44,6 @@ public final class MetaDataHandlerTest {
         metaDataHandler = new MetaDataHandler(subscribers);
     }
 
-    /**
-     * test case for {@link MetaDataHandler#convert(String)}.
-     */
     @Test
     public void testConvert() {
         List<MetaData> metaDataList = new LinkedList<>();
@@ -57,14 +52,9 @@ public final class MetaDataHandlerTest {
         Gson gson = new Gson();
         String json = gson.toJson(metaDataList);
         List<MetaData> convertedList = metaDataHandler.convert(json);
-        assertEquals(metaDataList, convertedList);
+        assertThat(convertedList, is(metaDataList));
     }
 
-    /**
-     * test case for {@link MetaDataHandler#doRefresh(List)}.
-     * First,verify that MetaDataSubscriber bean has called the {@link MetaDataSubscriber#refresh()} method.
-     * Then,verify that each MetaDataSubscriber bean has called the {@link MetaDataSubscriber#onSubscribe(MetaData)} method.
-     */
     @Test
     public void testDoRefresh() {
         List<MetaData> metaDataList = createFakeMetaDataObjects(3);
@@ -74,10 +64,6 @@ public final class MetaDataHandlerTest {
                 subscribers.forEach(subscriber -> verify(subscriber).onSubscribe(metaData)));
     }
 
-    /**
-     * test case for {@link MetaDataHandler#doUpdate(List)}.
-     * verify that each MetaDataSubscriber bean has called the {@link MetaDataSubscriber#onSubscribe(MetaData)} method.
-     */
     @Test
     public void testDoUpdate() {
         List<MetaData> metaDataList = createFakeMetaDataObjects(4);
@@ -86,10 +72,6 @@ public final class MetaDataHandlerTest {
                 subscribers.forEach(subscriber -> verify(subscriber).onSubscribe(metaData)));
     }
 
-    /**
-     * test case for {@link MetaDataHandler#doDelete(List)}.
-     * verify that each MetaDataSubscriber bean has called the {@link MetaDataSubscriber#unSubscribe(MetaData)} method.
-     */
     @Test
     public void testDoDelete() {
         List<MetaData> metaDataList = createFakeMetaDataObjects(3);

--- a/soul-sync-data-center/soul-sync-data-websocket/src/test/java/org/dromara/soul/plugin/sync/data/weboscket/handler/PluginDataHandlerTest.java
+++ b/soul-sync-data-center/soul-sync-data-websocket/src/test/java/org/dromara/soul/plugin/sync/data/weboscket/handler/PluginDataHandlerTest.java
@@ -21,17 +21,15 @@ import com.google.gson.Gson;
 import org.dromara.soul.common.dto.PluginData;
 import org.dromara.soul.sync.data.api.PluginDataSubscriber;
 import org.junit.Test;
+
 import java.util.LinkedList;
 import java.util.List;
-import static org.junit.Assert.assertEquals;
+
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-/**
- * Test cases for {@link PluginDataHandler}.
- *
- * @author cocoZwwang
- */
 public final class PluginDataHandlerTest {
 
     private final PluginDataSubscriber subscriber;
@@ -43,9 +41,6 @@ public final class PluginDataHandlerTest {
         pluginDataHandler = new PluginDataHandler(subscriber);
     }
 
-    /**
-     * test case for {@link PluginDataHandler#convert(String)}.
-     */
     @Test
     public void testConvert() {
         List<PluginData> pluginDataList = new LinkedList<>();
@@ -54,14 +49,9 @@ public final class PluginDataHandlerTest {
         Gson gson = new Gson();
         String json = gson.toJson(pluginDataList);
         List<PluginData> convertedList = pluginDataHandler.convert(json);
-        assertEquals(pluginDataList, convertedList);
+        assertThat(convertedList, is(pluginDataList));
     }
 
-    /**
-     * test case for {@link PluginDataHandler#doRefresh(List)}.
-     * First,verify the PluginDataSubscriber bean has called the {@link PluginDataSubscriber#refreshPluginDataSelf(List)} method.
-     * Then,verify the PluginDataSubscriber bean has called the {@link PluginDataSubscriber#onSubscribe(PluginData)} method.
-     */
     @Test
     public void testDoRefresh() {
         List<PluginData> pluginDataList = createFakePluginDataObjects(3);
@@ -70,10 +60,6 @@ public final class PluginDataHandlerTest {
         pluginDataList.forEach(verify(subscriber)::onSubscribe);
     }
 
-    /**
-     * test case for {@link PluginDataHandler#doUpdate(List)}.
-     * verify the PluginDataSubscriber bean has called the {@link PluginDataSubscriber#onSubscribe(PluginData)} method.
-     */
     @Test
     public void testDoUpdate() {
         List<PluginData> pluginDataList = createFakePluginDataObjects(4);
@@ -81,10 +67,6 @@ public final class PluginDataHandlerTest {
         pluginDataList.forEach(verify(subscriber)::onSubscribe);
     }
 
-    /**
-     * test case for {@link PluginDataHandler#doDelete(List)}.
-     * verify the PluginDataSubscriber bean has called the {@link PluginDataSubscriber#unSubscribe(PluginData)} method.
-     */
     @Test
     public void testDoDelete() {
         List<PluginData> pluginDataList = createFakePluginDataObjects(3);

--- a/soul-sync-data-center/soul-sync-data-websocket/src/test/java/org/dromara/soul/plugin/sync/data/weboscket/handler/RuleDataHandlerTest.java
+++ b/soul-sync-data-center/soul-sync-data-websocket/src/test/java/org/dromara/soul/plugin/sync/data/weboscket/handler/RuleDataHandlerTest.java
@@ -22,18 +22,16 @@ import org.dromara.soul.common.dto.ConditionData;
 import org.dromara.soul.common.dto.RuleData;
 import org.dromara.soul.sync.data.api.PluginDataSubscriber;
 import org.junit.Test;
+
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-import static org.junit.Assert.assertEquals;
+
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-/**
- * Test cases for {@link RuleDataHandler}.
- *
- * @author cocoZwwang
- */
 public final class RuleDataHandlerTest {
 
     private final PluginDataSubscriber subscriber;
@@ -45,9 +43,6 @@ public final class RuleDataHandlerTest {
         ruleDataHandler = new RuleDataHandler(subscriber);
     }
 
-    /**
-     * test case for {@link RuleDataHandler#convert(String)}.
-     */
     @Test
     public void testConvert() {
         List<RuleData> ruleDataList = new LinkedList<>();
@@ -59,14 +54,9 @@ public final class RuleDataHandlerTest {
         Gson gson = new Gson();
         String json = gson.toJson(ruleDataList);
         List<RuleData> convertedList = ruleDataHandler.convert(json);
-        assertEquals(ruleDataList, convertedList);
+        assertThat(convertedList, is(ruleDataList));
     }
 
-    /**
-     * test case for {@link RuleDataHandler#doRefresh(List)}.
-     * First,verify the PluginDataSubscriber bean has called the {@link PluginDataSubscriber#refreshRuleDataSelf(List)} method.
-     * Then,verify the PluginDataSubscriber bean has called the {@link PluginDataSubscriber#onRuleSubscribe(RuleData)} method.
-     */
     @Test
     public void testDoRefresh() {
         List<RuleData> ruleDataList = createFakeRuleDateObjects(3);
@@ -75,10 +65,6 @@ public final class RuleDataHandlerTest {
         ruleDataList.forEach(verify(subscriber)::onRuleSubscribe);
     }
 
-    /**
-     * test case for {@link RuleDataHandler#doUpdate(List)}.
-     * verify the PluginDataSubscriber bean has called the {@link PluginDataSubscriber#onRuleSubscribe(RuleData)} method.
-     */
     @Test
     public void testDoUpdate() {
         List<RuleData> ruleDataList = createFakeRuleDateObjects(4);
@@ -86,10 +72,6 @@ public final class RuleDataHandlerTest {
         ruleDataList.forEach(verify(subscriber)::onRuleSubscribe);
     }
 
-    /**
-     * test case for {@link RuleDataHandler#doDelete(List)}.
-     * verify the PluginDataSubscriber bean has called the {@link PluginDataSubscriber#unRuleSubscribe(RuleData)} method.
-     */
     @Test
     public void testDoDelete() {
         List<RuleData> ruleDataList = createFakeRuleDateObjects(3);

--- a/soul-sync-data-center/soul-sync-data-websocket/src/test/java/org/dromara/soul/plugin/sync/data/weboscket/handler/SelectorDataHandlerTest.java
+++ b/soul-sync-data-center/soul-sync-data-websocket/src/test/java/org/dromara/soul/plugin/sync/data/weboscket/handler/SelectorDataHandlerTest.java
@@ -22,18 +22,16 @@ import org.dromara.soul.common.dto.ConditionData;
 import org.dromara.soul.common.dto.SelectorData;
 import org.dromara.soul.sync.data.api.PluginDataSubscriber;
 import org.junit.Test;
+
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-import static org.junit.Assert.assertEquals;
+
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-/**
- * Test cases for {@link SelectorDataHandler}.
- *
- * @author cocoZwwang
- */
 public final class SelectorDataHandlerTest {
 
     private final PluginDataSubscriber subscriber;
@@ -45,9 +43,6 @@ public final class SelectorDataHandlerTest {
         selectorDataHandler = new SelectorDataHandler(subscriber);
     }
 
-    /**
-     * test case for {@link SelectorDataHandler#convert(String)}.
-     */
     @Test
     public void testConvert() {
         List<SelectorData> selectorDataList = new LinkedList<>();
@@ -59,14 +54,9 @@ public final class SelectorDataHandlerTest {
         Gson gson = new Gson();
         String json = gson.toJson(selectorDataList);
         List<SelectorData> convertedList = selectorDataHandler.convert(json);
-        assertEquals(selectorDataList, convertedList);
+        assertThat(convertedList, is(selectorDataList));
     }
 
-    /**
-     * test case for {@link SelectorDataHandler#doRefresh(List)}.
-     * First,verify the PluginDataSubscriber bean has called the {@link PluginDataSubscriber#refreshSelectorDataSelf(List)} method.
-     * Then,verify the PluginDataSubscriber bean has called the {@link PluginDataSubscriber#onSelectorSubscribe(SelectorData)} method.
-     */
     @Test
     public void testDoRefresh() {
         List<SelectorData> selectorDataList = createFakeSelectorDataObjects(3);
@@ -75,10 +65,6 @@ public final class SelectorDataHandlerTest {
         selectorDataList.forEach(verify(subscriber)::onSelectorSubscribe);
     }
 
-    /**
-     * test case for {@link SelectorDataHandler#doUpdate(List)}.
-     * verify the PluginDataSubscriber bean has called the {@link PluginDataSubscriber#onSelectorSubscribe(SelectorData)} method.
-     */
     @Test
     public void testDoUpdate() {
         List<SelectorData> selectorDataList = createFakeSelectorDataObjects(4);
@@ -86,10 +72,6 @@ public final class SelectorDataHandlerTest {
         selectorDataList.forEach(verify(subscriber)::onSelectorSubscribe);
     }
 
-    /**
-     * test case for {@link SelectorDataHandler#doDelete(List)}.
-     * verify the PluginDataSubscriber bean has called the {@link PluginDataSubscriber#unSelectorSubscribe(SelectorData)} method.
-     */
     @Test
     public void testDoDelete() {
         List<SelectorData> selectorDataList = createFakeSelectorDataObjects(3);

--- a/soul-sync-data-center/soul-sync-data-zookeeper/src/test/java/org/dromara/soul/sync/data/zookeeper/ZookeeperSyncDataServiceTest.java
+++ b/soul-sync-data-center/soul-sync-data-zookeeper/src/test/java/org/dromara/soul/sync/data/zookeeper/ZookeeperSyncDataServiceTest.java
@@ -41,54 +41,52 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static junit.framework.TestCase.assertTrue;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-/**
- * Test cases for ZookeeperSyncDataService.
- *
- * @author zendwang
- */
 @RunWith(MockitoJUnitRunner.class)
-public final class ZookeeperSyncDataServiceTest { 
-    
+public final class ZookeeperSyncDataServiceTest {
+
     private static final String MOCK_PLUGIN_PARENT_PATH = "/soul/plugin";
-    
+
     private static final String MOCK_PLUGIN_PATH = "/soul/plugin/divide";
-    
+
     private static final String MOCK_PLUGIN_NAME = "divide";
-    
+
     private static final String MOCK_SELECTOR_PARENT_PATH = "/soul/selector/divide";
-    
+
     private static final String MOCK_SELECTOR_PATH = "/soul/selector/divide/test";
-    
+
     private static final String MOCK_SELECTOR_NAME = "test";
-    
+
     private static final String MOCK_RULE_PARENT_PATH = "/soul/rule/divide";
-    
+
     private static final String MOCK_RULE_PATH = "/soul/rule/divide/test-test";
-    
+
     private static final String MOCK_RULE_NAME = "test-test";
-    
+
     private static final String MOCK_APP_AUTH_PARENT_PATH = "/soul/auth";
-    
+
     private static final String MOCK_APP_AUTH_PATH = "/soul/auth/test";
-    
+
     private static final String MOCK_APP_AUTH_KEY = "test";
-    
+
     private static final String MOCK_META_DATA_PARENT_PATH = "/soul/metaData";
-    
+
     private static final String MOCK_META_DATA_PATH = "/soul/metaData/test";
-    
+
     private static final String MOCK_META_DATA_ID = "test";
-    
+
     private ZkClient zkClient;
-    
+
     private ZookeeperSyncDataService syncDataService;
-    
+
     @Before
     public void setUp() {
         zkClient = mock(ZkClient.class);
@@ -114,7 +112,7 @@ public final class ZookeeperSyncDataServiceTest {
         when(zkClient.readData(MOCK_META_DATA_PATH)).thenReturn(metaData);
         when(zkClient.getChildren(MOCK_META_DATA_PARENT_PATH)).thenReturn(Lists.newArrayList(MOCK_META_DATA_ID));
     }
-    
+
     @Test
     public void testWatchPluginWhenInit() {
         final List<PluginData> subscribeList = new ArrayList<>(1);
@@ -124,10 +122,10 @@ public final class ZookeeperSyncDataServiceTest {
                 subscribeList.add(pluginData);
             }
         }, Collections.emptyList(), Collections.emptyList());
-        Assert.assertEquals(1, subscribeList.size());
-        Assert.assertEquals("divide", subscribeList.get(0).getName());
+        assertThat(subscribeList.size(), is(1));
+        assertThat(subscribeList.get(0).getName(), is("divide"));
     }
-    
+
     @Test
     public void testWatchPluginWhenDataChange() throws Exception {
         final PluginData changedPluginData = PluginData.builder().name(MOCK_PLUGIN_NAME).enabled(Boolean.TRUE).build();
@@ -141,10 +139,10 @@ public final class ZookeeperSyncDataServiceTest {
         ArgumentCaptor<IZkDataListener> captor = ArgumentCaptor.forClass(IZkDataListener.class);
         verify(zkClient).subscribeDataChanges(eq(MOCK_PLUGIN_PATH), captor.capture());
         captor.getValue().handleDataChange(MOCK_PLUGIN_PATH, changedPluginData);
-        Assert.assertEquals(2, subscribeList.size());
-        Assert.assertTrue(subscribeList.get(1).getEnabled());
+        assertThat(subscribeList.size(), is(2));
+        assertTrue(subscribeList.get(1).getEnabled());
     }
-    
+
     @Test
     public void testWatchPluginWhenDataDeleted() throws Exception {
         final List<PluginData> unSubscribeList = new ArrayList<>(1);
@@ -154,14 +152,13 @@ public final class ZookeeperSyncDataServiceTest {
                 unSubscribeList.add(pluginData);
             }
         }, Collections.emptyList(), Collections.emptyList());
-     
         ArgumentCaptor<IZkDataListener> captor = ArgumentCaptor.forClass(IZkDataListener.class);
         verify(zkClient).subscribeDataChanges(eq(MOCK_PLUGIN_PATH), captor.capture());
         captor.getValue().handleDataDeleted(MOCK_PLUGIN_PATH);
-        Assert.assertEquals(1, unSubscribeList.size());
-        Assert.assertEquals("divide", unSubscribeList.get(0).getName());
+        assertThat(unSubscribeList.size(), is(1));
+        assertThat(unSubscribeList.get(0).getName(), is("divide"));
     }
-    
+
     @Test
     public void testWatchSelectorWhenInit() {
         final List<SelectorData> subscribeList = new ArrayList<>(1);
@@ -171,8 +168,8 @@ public final class ZookeeperSyncDataServiceTest {
                 subscribeList.add(selectorData);
             }
         }, Collections.emptyList(), Collections.emptyList());
-        Assert.assertEquals(1, subscribeList.size());
-        Assert.assertEquals("test", subscribeList.get(0).getName());
+        assertThat(subscribeList.size(), is(1));
+        assertThat(subscribeList.get(0).getName(), is("test"));
     }
 
     @Test
@@ -188,8 +185,8 @@ public final class ZookeeperSyncDataServiceTest {
         ArgumentCaptor<IZkDataListener> captor = ArgumentCaptor.forClass(IZkDataListener.class);
         verify(zkClient).subscribeDataChanges(eq(MOCK_SELECTOR_PATH), captor.capture());
         captor.getValue().handleDataChange(MOCK_SELECTOR_PATH, changedSelectorData);
-        Assert.assertEquals(2, subscribeList.size());
-        Assert.assertTrue(subscribeList.get(1).getEnabled());
+        assertThat(subscribeList.size(), is(2));
+        assertTrue(subscribeList.get(1).getEnabled());
     }
 
     @Test
@@ -204,8 +201,8 @@ public final class ZookeeperSyncDataServiceTest {
         ArgumentCaptor<IZkDataListener> captor = ArgumentCaptor.forClass(IZkDataListener.class);
         verify(zkClient).subscribeDataChanges(eq(MOCK_SELECTOR_PATH), captor.capture());
         captor.getValue().handleDataDeleted(MOCK_SELECTOR_PATH);
-        Assert.assertEquals(1, unSubscribeList.size());
-        Assert.assertEquals("test", unSubscribeList.get(0).getId());
+        assertThat(unSubscribeList.size(), is(1));
+        assertThat(unSubscribeList.get(0).getId(), is("test"));
     }
 
     @Test
@@ -217,8 +214,8 @@ public final class ZookeeperSyncDataServiceTest {
                 subscribeList.add(ruleData);
             }
         }, Collections.emptyList(), Collections.emptyList());
-        Assert.assertEquals(1, subscribeList.size());
-        Assert.assertEquals(MOCK_RULE_NAME, subscribeList.get(0).getName());
+        assertThat(subscribeList.size(), is(1));
+        assertThat(subscribeList.get(0).getName(), is(MOCK_RULE_NAME));
     }
 
     @Test
@@ -234,7 +231,7 @@ public final class ZookeeperSyncDataServiceTest {
         ArgumentCaptor<IZkDataListener> captor = ArgumentCaptor.forClass(IZkDataListener.class);
         verify(zkClient).subscribeDataChanges(eq(MOCK_RULE_PATH), captor.capture());
         captor.getValue().handleDataChange(MOCK_RULE_PATH, changedRuleData);
-        Assert.assertEquals(2, subscribeList.size());
+        assertThat(subscribeList.size(), is(2));
         Assert.assertTrue(subscribeList.get(1).getEnabled());
     }
 
@@ -250,10 +247,10 @@ public final class ZookeeperSyncDataServiceTest {
         ArgumentCaptor<IZkDataListener> captor = ArgumentCaptor.forClass(IZkDataListener.class);
         verify(zkClient).subscribeDataChanges(eq(MOCK_RULE_PATH), captor.capture());
         captor.getValue().handleDataDeleted(MOCK_RULE_PATH);
-        Assert.assertEquals(1, unSubscribeList.size());
-        Assert.assertEquals(MOCK_RULE_NAME, unSubscribeList.get(0).getSelectorId() + ZkPathConstants.SELECTOR_JOIN_RULE + unSubscribeList.get(0).getId());
+        assertThat(unSubscribeList.size(), is(1));
+        assertThat(unSubscribeList.get(0).getSelectorId() + ZkPathConstants.SELECTOR_JOIN_RULE + unSubscribeList.get(0).getId(), is(MOCK_RULE_NAME));
     }
-    
+
     @Test
     public void testWatchAppAuthWhenInit() {
         final List<AppAuthData> subscribeList = new ArrayList<>(1);
@@ -262,14 +259,14 @@ public final class ZookeeperSyncDataServiceTest {
             public void onSubscribe(final AppAuthData appAuthData) {
                 subscribeList.add(appAuthData);
             }
-            
+
             @Override
             public void unSubscribe(final AppAuthData appAuthData) {
             }
         };
         syncDataService = new ZookeeperSyncDataService(zkClient,
                 null, Collections.emptyList(), Lists.newArrayList(authDataSubscriber));
-        Assert.assertEquals(1, subscribeList.size());
+        assertThat(subscribeList.size(), is(1));
     }
 
     @Test
@@ -281,7 +278,7 @@ public final class ZookeeperSyncDataServiceTest {
             public void onSubscribe(final AppAuthData appAuthData) {
                 subscribeList.add(appAuthData);
             }
-        
+
             @Override
             public void unSubscribe(final AppAuthData appAuthData) {
             }
@@ -291,8 +288,8 @@ public final class ZookeeperSyncDataServiceTest {
         ArgumentCaptor<IZkDataListener> captor = ArgumentCaptor.forClass(IZkDataListener.class);
         verify(zkClient).subscribeDataChanges(eq(MOCK_APP_AUTH_PATH), captor.capture());
         captor.getValue().handleDataChange(MOCK_APP_AUTH_PATH, changedAppAuthData);
-        Assert.assertEquals(2, subscribeList.size());
-        Assert.assertTrue(subscribeList.get(1).getEnabled());
+        assertThat(subscribeList.size(), is(2));
+        assertTrue(subscribeList.get(1).getEnabled());
     }
 
     @Test
@@ -302,7 +299,7 @@ public final class ZookeeperSyncDataServiceTest {
             @Override
             public void onSubscribe(final AppAuthData appAuthData) {
             }
-        
+
             @Override
             public void unSubscribe(final AppAuthData appAuthData) {
                 unSubscribeList.add(appAuthData);
@@ -313,8 +310,8 @@ public final class ZookeeperSyncDataServiceTest {
         ArgumentCaptor<IZkDataListener> captor = ArgumentCaptor.forClass(IZkDataListener.class);
         verify(zkClient).subscribeDataChanges(eq(MOCK_APP_AUTH_PATH), captor.capture());
         captor.getValue().handleDataDeleted(MOCK_APP_AUTH_PATH);
-        Assert.assertEquals(1, unSubscribeList.size());
-        Assert.assertEquals(MOCK_APP_AUTH_KEY, unSubscribeList.get(0).getAppKey());
+        assertThat(unSubscribeList.size(), is(1));
+        assertThat(unSubscribeList.get(0).getAppKey(), is(MOCK_APP_AUTH_KEY));
     }
 
     @Test
@@ -332,7 +329,7 @@ public final class ZookeeperSyncDataServiceTest {
         };
         syncDataService = new ZookeeperSyncDataService(zkClient,
                 null, Lists.newArrayList(metaDataSubscriber), Collections.emptyList());
-        Assert.assertEquals(1, subscribeList.size());
+        assertThat(subscribeList.size(), is(1));
     }
 
     @Test
@@ -344,7 +341,7 @@ public final class ZookeeperSyncDataServiceTest {
             public void onSubscribe(final MetaData metaData) {
                 subscribeList.add(metaData);
             }
-        
+
             @Override
             public void unSubscribe(final MetaData metaData) {
             }
@@ -355,8 +352,8 @@ public final class ZookeeperSyncDataServiceTest {
         ArgumentCaptor<IZkDataListener> captor = ArgumentCaptor.forClass(IZkDataListener.class);
         verify(zkClient).subscribeDataChanges(eq(MOCK_META_DATA_PATH), captor.capture());
         captor.getValue().handleDataChange(MOCK_META_DATA_PATH, changedMetaData);
-        Assert.assertEquals(2, subscribeList.size());
-        Assert.assertTrue(subscribeList.get(1).getEnabled());
+        assertThat(subscribeList.size(), is(2));
+        assertTrue(subscribeList.get(1).getEnabled());
     }
 
     @Test
@@ -366,7 +363,7 @@ public final class ZookeeperSyncDataServiceTest {
             @Override
             public void onSubscribe(final MetaData metaData) {
             }
-        
+
             @Override
             public void unSubscribe(final MetaData metaData) {
                 unSubscribeList.add(metaData);
@@ -377,10 +374,10 @@ public final class ZookeeperSyncDataServiceTest {
         ArgumentCaptor<IZkDataListener> captor = ArgumentCaptor.forClass(IZkDataListener.class);
         verify(zkClient).subscribeDataChanges(eq(MOCK_META_DATA_PATH), captor.capture());
         captor.getValue().handleDataDeleted(MOCK_META_DATA_PATH);
-        Assert.assertEquals(1, unSubscribeList.size());
-        Assert.assertEquals(MOCK_META_DATA_ID, unSubscribeList.get(0).getPath());
+        assertThat(unSubscribeList.size(), is(1));
+        assertThat(unSubscribeList.get(0).getPath(), is(MOCK_META_DATA_ID));
     }
-    
+
     @After
     public void tearDown() {
         syncDataService.close();


### PR DESCRIPTION
 #945 
assertEquals() has been Modified to assertThat()
Use inline import static class in test case , just like import static org.mockito.Mockito.mock;, import static org.junit.Assert.assertTrue;
Delete unnecessary blank lines.
Optimize the java doc.
There is no obvious yellow warning of IDEA.
Remove the final variable Inside the method.
Use constants for all string variables.
English words should be expressed clearly. for example : setUp maybe to setup.