### PR TITLE
Remove duplicate dependencies for pom.xml.

### DIFF
--- a/soul-metrics/soul-metrics-facade/pom.xml
+++ b/soul-metrics/soul-metrics-facade/pom.xml
@@ -31,17 +31,7 @@
     <dependencies>
         <dependency>
             <groupId>org.dromara</groupId>
-            <artifactId>soul-metrics-spi</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.dromara</groupId>
             <artifactId>soul-common</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.dromara</groupId>
-            <artifactId>soul-spi</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/soul-metrics/soul-metrics-prometheus/pom.xml
+++ b/soul-metrics/soul-metrics-prometheus/pom.xml
@@ -41,11 +41,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.dromara</groupId>
-            <artifactId>soul-spi</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient</artifactId>
         </dependency>

--- a/soul-plugin/soul-plugin-base/pom.xml
+++ b/soul-plugin/soul-plugin-base/pom.xml
@@ -31,11 +31,6 @@
     <dependencies>
         <dependency>
             <groupId>org.dromara</groupId>
-            <artifactId>soul-common</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.dromara</groupId>
             <artifactId>soul-plugin-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/soul-plugin/soul-plugin-divide/pom.xml
+++ b/soul-plugin/soul-plugin-divide/pom.xml
@@ -34,11 +34,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.dromara</groupId>
-            <artifactId>soul-spi</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-test</artifactId>
             <scope>test</scope>

--- a/soul-plugin/soul-plugin-monitor/pom.xml
+++ b/soul-plugin/soul-plugin-monitor/pom.xml
@@ -40,17 +40,6 @@
             <artifactId>soul-metrics-facade</artifactId>
             <version>${project.version}</version>
         </dependency>
-
-        <dependency>
-            <groupId>org.dromara</groupId>
-            <artifactId>soul-metrics-prometheus</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.dromara</groupId>
-            <artifactId>soul-metrics-spi</artifactId>
-            <version>${project.version}</version>
-        </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>

--- a/soul-web/pom.xml
+++ b/soul-web/pom.xml
@@ -32,12 +32,6 @@
 
         <dependency>
             <groupId>org.dromara</groupId>
-            <artifactId>soul-plugin-api</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.dromara</groupId>
             <artifactId>soul-spring-boot-starter-plugin-global</artifactId>
             <version>${project.version}</version>
         </dependency>


### PR DESCRIPTION
Below is the removed duplicate dependencies check list：
- soul-web/pom.xml:   				soul-plugin-api
- soul-plugin/soul-plugin-base: 		soul-common
- soul-metrics/soul-metrics-facade:	soul-spi & soul-metrics-spi
- soul-plugin-monitor:				soul-spi & soul-metrics-prometheus

This is the current component dependencies diagram:
![image](https://user-images.githubusercontent.com/9609929/104952138-e4325080-59fe-11eb-8a43-25f5e1d41eef.png)

I removed the dependency represented by the red line. After removed duplicate dependencies:
![image](https://user-images.githubusercontent.com/9609929/104952210-02984c00-59ff-11eb-80ce-88c0c74797c7.png)
