### PR TITLE
Add final for `execute` method.

### DIFF
--- a/soul-plugin/soul-plugin-base/src/main/java/org/dromara/soul/plugin/base/AbstractSoulPlugin.java
+++ b/soul-plugin/soul-plugin-base/src/main/java/org/dromara/soul/plugin/base/AbstractSoulPlugin.java
@@ -66,7 +66,7 @@ public abstract class AbstractSoulPlugin implements SoulPlugin {
      * @return {@code Mono<Void>} to indicate when request processing is complete
      */
     @Override
-    public Mono<Void> execute(final ServerWebExchange exchange, final SoulPluginChain chain) {
+    public final Mono<Void> execute(final ServerWebExchange exchange, final SoulPluginChain chain) {
         String pluginName = named();
         final PluginData pluginData = BaseDataCache.getInstance().obtainPluginData(pluginName);
         if (pluginData != null && pluginData.getEnabled()) {


### PR DESCRIPTION
`execute` method is designed as a template method, so the final keyword should be used to prevent subclasses from overriding the implementation of the `execute` method.