### PR TITLE
Add test for FileSizeFilter, and change the initialCapacity for the changedGroup list.

### DIFF
--- a/soul-admin/src/main/java/org/dromara/soul/admin/listener/http/HttpLongPollingDataChangedListener.java
+++ b/soul-admin/src/main/java/org/dromara/soul/admin/listener/http/HttpLongPollingDataChangedListener.java
@@ -176,7 +176,7 @@ public class HttpLongPollingDataChangedListener extends AbstractDataChangedListe
     }
 
     private List<ConfigGroupEnum> compareChangedGroup(final HttpServletRequest request) {
-        List<ConfigGroupEnum> changedGroup = new ArrayList<>(4);
+        List<ConfigGroupEnum> changedGroup = new ArrayList<>(ConfigGroupEnum.values().length);
         for (ConfigGroupEnum group : ConfigGroupEnum.values()) {
             // md5,lastModifyTime
             String[] params = StringUtils.split(request.getParameter(group.name()), ',');

--- a/soul-web/src/test/java/org/dromara/soul/web/filter/FileSizeFilterTest.java
+++ b/soul-web/src/test/java/org/dromara/soul/web/filter/FileSizeFilterTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dromara.soul.web.filter;
+
+import org.dromara.soul.plugin.api.result.SoulResult;
+import org.dromara.soul.plugin.base.utils.SpringBeanUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+import static org.springframework.http.MediaType.MULTIPART_FORM_DATA;
+
+/**
+ * test case for FileSizeFilter.
+ *
+ * @author hellboy0621
+ **/
+public class FileSizeFilterTest {
+
+    @Before
+    public void setup() {
+        GenericApplicationContext context = new GenericApplicationContext();
+        SpringBeanUtils.getInstance().setCfgContext(context);
+        context.getBeanFactory().registerSingleton("soulResult", mock(SoulResult.class));
+        context.refresh();
+    }
+
+    @Test
+    public void testFilter() {
+        ServerWebExchange webExchange =
+                MockServerWebExchange.from(MockServerHttpRequest
+                        .post("http://localhost:8080")
+                        .contentType(MediaType.TEXT_PLAIN)
+                        .contentLength(4)
+                        .body("test"));
+
+        ServerHttpRequest mutatedRequest = webExchange.getRequest().mutate().header(CONTENT_TYPE,
+                String.valueOf(MULTIPART_FORM_DATA)).build();
+        webExchange = webExchange.mutate().request(mutatedRequest).build();
+
+        WebFilterChain webFilterChain = mock(WebFilterChain.class);
+        when(webFilterChain.filter(any())).thenReturn(Mono.empty());
+
+        FileSizeFilter fileSizeFilter = new FileSizeFilter(0);
+        Mono<Void> voidMono = fileSizeFilter.filter(webExchange, webFilterChain);
+        StepVerifier.create(voidMono).expectSubscription().verifyComplete();
+
+        fileSizeFilter = new FileSizeFilter(1);
+        voidMono = fileSizeFilter.filter(webExchange, webFilterChain);
+        StepVerifier.create(voidMono).expectSubscription().verifyComplete();
+    }
+}


### PR DESCRIPTION
Fixes #867 
Add test for FileSizeFilter, and change the initialCapacity for the changedGroup list (because ConfigGroupEnum has 5 elements).

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://dromara.org/en-us/docs/soul/contributor.html).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `mvn clean install -Dmaven.javadoc.skip=true`.
