### PR TITLE
optimize client-springmvc registration time

### DIFF
--- a/soul-client/soul-client-http/soul-client-springmvc/src/main/java/org/dromara/soul/client/springmvc/init/ContextRegisterListener.java
+++ b/soul-client/soul-client-http/soul-client-springmvc/src/main/java/org/dromara/soul/client/springmvc/init/ContextRegisterListener.java
@@ -26,8 +26,8 @@ import org.dromara.soul.client.springmvc.dto.SpringMvcRegisterDTO;
 import org.dromara.soul.client.springmvc.utils.ValidateUtils;
 import org.dromara.soul.common.enums.RpcTypeEnum;
 import org.dromara.soul.common.utils.IpUtils;
-import org.springframework.context.ApplicationListener;
-import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -35,7 +35,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * The type Context register listener.
  */
 @Slf4j
-public class ContextRegisterListener implements ApplicationListener<ContextRefreshedEvent> {
+public class ContextRegisterListener implements ApplicationRunner {
 
     private final AtomicBoolean registered = new AtomicBoolean(false);
 
@@ -55,7 +55,7 @@ public class ContextRegisterListener implements ApplicationListener<ContextRefre
     }
 
     @Override
-    public void onApplicationEvent(final ContextRefreshedEvent contextRefreshedEvent) {
+    public void run(final ApplicationArguments args) {
         if (!registered.compareAndSet(false, true)) {
             return;
         }
@@ -83,4 +83,5 @@ public class ContextRegisterListener implements ApplicationListener<ContextRefre
                 .build();
         return OkHttpTools.getInstance().getGson().toJson(registerDTO);
     }
+
 }

--- a/soul-client/soul-client-http/soul-client-springmvc/src/test/java/org/dromara/soul/client/springmvc/init/ContextRegisterListenerTest.java
+++ b/soul-client/soul-client-http/soul-client-springmvc/src/test/java/org/dromara/soul/client/springmvc/init/ContextRegisterListenerTest.java
@@ -32,7 +32,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 
-import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.boot.ApplicationArguments;
 
 /**
  * Test case for {@link ContextRegisterListenerTest}.
@@ -51,8 +51,8 @@ public final class ContextRegisterListenerTest {
         soulSpringMvcConfig.setContextPath("test");
         soulSpringMvcConfig.setPort(58889);
         ContextRegisterListener contextRegisterListener = new ContextRegisterListener(soulSpringMvcConfig);
-        ContextRefreshedEvent contextRefreshedEvent = mock(ContextRefreshedEvent.class);
-        contextRegisterListener.onApplicationEvent(contextRefreshedEvent);
+        ApplicationArguments applicationArguments = mock(ApplicationArguments.class);
+        contextRegisterListener.run(applicationArguments);
     }
 
     @Test
@@ -65,8 +65,8 @@ public final class ContextRegisterListenerTest {
             soulSpringMvcConfig.setFull(true);
             soulSpringMvcConfig.setPort(58889);
             ContextRegisterListener contextRegisterListener = new ContextRegisterListener(soulSpringMvcConfig);
-            ContextRefreshedEvent contextRefreshedEvent = mock(ContextRefreshedEvent.class);
-            contextRegisterListener.onApplicationEvent(contextRefreshedEvent);
+            ApplicationArguments applicationArguments = mock(ApplicationArguments.class);
+            contextRegisterListener.run(applicationArguments);
 
             mocked.verify(() -> RegisterUtils.doRegister(anyString(), eq("http://127.0.0.1:8080/soul-client/springmvc-register"), eq(RpcTypeEnum.HTTP)));
         }


### PR DESCRIPTION
optimize client-springmvc registration time
It could be an example！
When registering, the project may not start successfully, but it just collides with polling, resulting in invalid registration

 [Please see the detailed description of the](https://www.yuque.com/tanning/epv4c9/bwbs88)

 
- [x] You have read the [contribution guidelines](https://dromara.org/en-us/docs/soul/contributor.html).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `mvn clean install -Dmaven.javadoc.skip=true`.