### PR TITLE
Make the return value of tars compatible with primitive types

### DIFF
--- a/soul-examples/soul-examples-grpc/pom.xml
+++ b/soul-examples/soul-examples-grpc/pom.xml
@@ -30,6 +30,7 @@
     <properties>
         <grpc.version>1.33.1</grpc.version>
         <protobuf.version>3.13.0</protobuf.version>
+        <os-maven-plugin.version>1.6.2</os-maven-plugin.version>
     </properties>
 
     <dependencies>
@@ -67,18 +68,10 @@
             <extension>
                 <groupId>kr.motd.maven</groupId>
                 <artifactId>os-maven-plugin</artifactId>
-                <version>1.6.2</version>
+                <version>${os-maven-plugin.version}</version>
             </extension>
         </extensions>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>8</source>
-                    <target>8</target>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>

--- a/soul-examples/soul-examples-tars/src/main/java/org/dromara/soul/examples/tars/servant/testapp/HelloServant.java
+++ b/soul-examples/soul-examples-tars/src/main/java/org/dromara/soul/examples/tars/servant/testapp/HelloServant.java
@@ -14,5 +14,6 @@ public interface HelloServant {
 
 	 String hello(@TarsMethodParameter(name="no")int no, @TarsMethodParameter(name="name")String name);
 
-	 Integer helloInt(@TarsMethodParameter(name="no")int no, @TarsMethodParameter(name="name")String name);
+	 int helloInt(@TarsMethodParameter(name="no")int no, @TarsMethodParameter(name="name")String name);
+
 }

--- a/soul-examples/soul-examples-tars/src/main/java/org/dromara/soul/examples/tars/servant/testapp/impl/HelloServantImpl.java
+++ b/soul-examples/soul-examples-tars/src/main/java/org/dromara/soul/examples/tars/servant/testapp/impl/HelloServantImpl.java
@@ -36,7 +36,7 @@ public class HelloServantImpl implements HelloServant {
 
     @Override
     @SoulTarsClient(path = "/helloInt")
-    public Integer helloInt(int no, String name) {
+    public int helloInt(int no, String name) {
         return 1;
     }
 }

--- a/soul-examples/soul-examples-tars/src/main/resources/test.tars
+++ b/soul-examples/soul-examples-tars/src/main/resources/test.tars
@@ -3,5 +3,6 @@ module TestApp
     interface Hello
     {
         string hello(int no, string name);
+        int helloInt(int no, string name);
     };
 };

--- a/soul-plugin/soul-plugin-tars/src/main/java/org/dromara/soul/plugin/tars/cache/ApplicationConfigCache.java
+++ b/soul-plugin/soul-plugin-tars/src/main/java/org/dromara/soul/plugin/tars/cache/ApplicationConfigCache.java
@@ -127,7 +127,7 @@ public final class ApplicationConfigCache {
                             for (MethodInfo methodInfo : tarsParamExtInfo.getMethodInfo()) {
                                 DynamicType.Builder.MethodDefinition.ParameterDefinition<?> definition =
                                         classDefinition.defineMethod(PrxInfoUtil.getMethodName(methodInfo.methodName),
-                                                ReturnValueResolver.getCallBackType(Class.forName(methodInfo.getReturnType())),
+                                                ReturnValueResolver.getCallBackType(PrxInfoUtil.getParamClass(methodInfo.getReturnType())),
                                                 Visibility.PUBLIC);
                                 if (CollectionUtils.isNotEmpty(methodInfo.getParams())) {
                                     Class<?>[] paramTypes = new Class[methodInfo.getParams().size()];
@@ -210,7 +210,7 @@ public final class ApplicationConfigCache {
      */
     @Data
     static class MethodInfo {
-        
+
         private String methodName;
 
         private List<Pair<String, String>> params;
@@ -223,7 +223,7 @@ public final class ApplicationConfigCache {
      */
     @Data
     static class TarsParamExtInfo {
-        
+
         private List<MethodInfo> methodInfo;
     }
 
@@ -233,7 +233,7 @@ public final class ApplicationConfigCache {
     @Data
     @AllArgsConstructor
     static class TarsParamInfo {
-        
+
         private Class<?>[] paramTypes;
 
         private String[] paramNames;

--- a/soul-plugin/soul-plugin-tars/src/main/java/org/dromara/soul/plugin/tars/util/ReturnValueResolver.java
+++ b/soul-plugin/soul-plugin-tars/src/main/java/org/dromara/soul/plugin/tars/util/ReturnValueResolver.java
@@ -21,6 +21,8 @@ import com.google.common.reflect.TypeParameter;
 import com.google.common.reflect.TypeToken;
 
 import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -29,6 +31,20 @@ import java.util.concurrent.CompletableFuture;
  * @author tydhot
  */
 public class ReturnValueResolver {
+
+    private static final Map<Class, Class> WRAPPER_TYPE_MAP;
+
+    static {
+        WRAPPER_TYPE_MAP = new HashMap<>();
+        WRAPPER_TYPE_MAP.put(int.class, Integer.class);
+        WRAPPER_TYPE_MAP.put(byte.class, Byte.class);
+        WRAPPER_TYPE_MAP.put(char.class, Character.class);
+        WRAPPER_TYPE_MAP.put(boolean.class, Boolean.class);
+        WRAPPER_TYPE_MAP.put(double.class, Double.class);
+        WRAPPER_TYPE_MAP.put(float.class, Float.class);
+        WRAPPER_TYPE_MAP.put(long.class, Long.class);
+        WRAPPER_TYPE_MAP.put(short.class, Short.class);
+    }
 
     /**
      * Get return type.
@@ -39,8 +55,8 @@ public class ReturnValueResolver {
      */
     public static <T> Type getCallBackType(final Class<T> clazz) {
         return new TypeToken<CompletableFuture<T>>() { }
-            .where(new TypeParameter<T>() { }, TypeToken.of(clazz))
-            .getType();
+                .where(new TypeParameter<T>() { }, TypeToken.of(WRAPPER_TYPE_MAP.getOrDefault(clazz, clazz)))
+                .getType();
     }
 
 }


### PR DESCRIPTION
Now, It will occur the follow exception when the return value of `tars ` method is `int`:
```
@SoulTarsClient(path = "/helloInt")
public int helloInt(int no, String name) {
    return 1;
}
```
<details>
<summary>Click to see error log</summary>

```
java.lang.ClassNotFoundException: int
	at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:349)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	at java.lang.Class.forName0(Native Method)
	at java.lang.Class.forName(Class.java:264)
	at org.dromara.soul.plugin.tars.cache.ApplicationConfigCache.initPrx(ApplicationConfigCache.java:132)
	at org.dromara.soul.plugin.tars.subscriber.TarsMetaDataSubscriber.onSubscribe(TarsMetaDataSubscriber.java:50)
	at org.dromara.soul.plugin.sync.data.websocket.handler.MetaDataHandler.lambda$null$0(MetaDataHandler.java:42)
	at java.util.ArrayList.forEach(ArrayList.java:1257)
	at org.dromara.soul.plugin.sync.data.websocket.handler.MetaDataHandler.lambda$doRefresh$1(MetaDataHandler.java:42)
	at java.util.ArrayList.forEach(ArrayList.java:1257)
	at org.dromara.soul.plugin.sync.data.websocket.handler.MetaDataHandler.doRefresh(MetaDataHandler.java:42)
	at org.dromara.soul.plugin.sync.data.websocket.handler.AbstractDataHandler.handle(AbstractDataHandler.java:68)
	at org.dromara.soul.plugin.sync.data.websocket.handler.WebsocketDataHandler.executor(WebsocketDataHandler.java:61)
	at org.dromara.soul.plugin.sync.data.websocket.client.SoulWebsocketClient.handleResult(SoulWebsocketClient.java:87)
	at org.dromara.soul.plugin.sync.data.websocket.client.SoulWebsocketClient.onMessage(SoulWebsocketClient.java:68)
	at org.java_websocket.client.WebSocketClient.onWebsocketMessage(WebSocketClient.java:591)
	at org.java_websocket.drafts.Draft_6455.processFrameText(Draft_6455.java:885)
	at org.java_websocket.drafts.Draft_6455.processFrame(Draft_6455.java:819)
	at org.java_websocket.WebSocketImpl.decodeFrames(WebSocketImpl.java:379)
	at org.java_websocket.WebSocketImpl.decode(WebSocketImpl.java:216)
	at org.java_websocket.client.WebSocketClient.run(WebSocketClient.java:508)
	at java.lang.Thread.run(Thread.java:748)
java.lang.ClassNotFoundException: int
	at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:349)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	at java.lang.Class.forName0(Native Method)
	at java.lang.Class.forName(Class.java:264)
	at org.dromara.soul.plugin.tars.cache.ApplicationConfigCache.initPrx(ApplicationConfigCache.java:132)
	at org.dromara.soul.plugin.tars.subscriber.TarsMetaDataSubscriber.onSubscribe(TarsMetaDataSubscriber.java:50)
	at org.dromara.soul.plugin.sync.data.websocket.handler.MetaDataHandler.lambda$null$0(MetaDataHandler.java:42)
	at java.util.ArrayList.forEach(ArrayList.java:1257)
	at org.dromara.soul.plugin.sync.data.websocket.handler.MetaDataHandler.lambda$doRefresh$1(MetaDataHandler.java:42)
	at java.util.ArrayList.forEach(ArrayList.java:1257)
	at org.dromara.soul.plugin.sync.data.websocket.handler.MetaDataHandler.doRefresh(MetaDataHandler.java:42)
	at org.dromara.soul.plugin.sync.data.websocket.handler.AbstractDataHandler.handle(AbstractDataHandler.java:68)
	at org.dromara.soul.plugin.sync.data.websocket.handler.WebsocketDataHandler.executor(WebsocketDataHandler.java:61)
	at org.dromara.soul.plugin.sync.data.websocket.client.SoulWebsocketClient.handleResult(SoulWebsocketClient.java:87)
	at org.dromara.soul.plugin.sync.data.websocket.client.SoulWebsocketClient.onMessage(SoulWebsocketClient.java:68)
	at org.java_websocket.client.WebSocketClient.onWebsocketMessage(WebSocketClient.java:591)
	at org.java_websocket.drafts.Draft_6455.processFrameText(Draft_6455.java:885)
	at org.java_websocket.drafts.Draft_6455.processFrame(Draft_6455.java:819)
	at org.java_websocket.WebSocketImpl.decodeFrames(WebSocketImpl.java:379)
	at org.java_websocket.WebSocketImpl.decode(WebSocketImpl.java:216)
	at org.java_websocket.client.WebSocketClient.run(WebSocketClient.java:508)
	at java.lang.Thread.run(Thread.java:748)
2021-02-21 12:27:23.450 ERROR 11356 --- [ctReadThread-22] o.d.s.p.t.cache.ApplicationConfigCache   : init tars ref ex:int
```
</details>

That's caused by this line of code `ReturnValueResolver.getCallBackType(Class.forName(methodInfo.getReturnType())),`

Fix: Make the return value of tars compatible with primitive types
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://dromara.org/en-us/docs/soul/contributor.html).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `mvn clean install -Dmaven.javadoc.skip=true`.
