### PR TITLE
fix sql can't execute when mysql database name has been changed

### DIFF
--- a/soul-admin/src/main/resources/META-INF/schema.sql
+++ b/soul-admin/src/main/resources/META-INF/schema.sql
@@ -14,9 +14,7 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-CREATE DATABASE  IF NOT EXISTS  `soul`  DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ;
 
-USE `soul`;
 
 /*Table structure for table `dashboard_user` */
 CREATE TABLE IF NOT EXISTS `dashboard_user` (


### PR DESCRIPTION
// Describe your PR here; eg. Fixes #issueNo


Make sure that:

- [x] You have read the [contribution guidelines](https://dromara.org/projects/soul/contributor/).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `mvn clean install -Dmaven.javadoc.skip=true`.
