### PR TITLE
spring cloud client support config servlet.context-path and fix "null/**" path for metadata when soul`s contextPath is null

### DIFF
--- a/soul-client/soul-client-http/soul-client-springcloud/src/main/java/org/dromara/soul/client/springcloud/init/SpringCloudClientBeanPostProcessor.java
+++ b/soul-client/soul-client-http/soul-client-springcloud/src/main/java/org/dromara/soul/client/springcloud/init/SpringCloudClientBeanPostProcessor.java
@@ -63,6 +63,8 @@ public class SpringCloudClientBeanPostProcessor implements BeanPostProcessor {
     private final String host;
 
     private final String port;
+
+    private final String servletContextPath;
     
     /**
      * Instantiates a new Soul client bean post processor.
@@ -87,6 +89,7 @@ public class SpringCloudClientBeanPostProcessor implements BeanPostProcessor {
         this.isFull = Boolean.parseBoolean(props.getProperty("isFull", "false"));
         this.host = config.getProps().getProperty("host");
         this.port = config.getProps().getProperty("port");
+        this.servletContextPath = env.getProperty("server.servlet.context-path", "");
         publisher.start(soulClientRegisterRepository);
     }
 
@@ -123,14 +126,9 @@ public class SpringCloudClientBeanPostProcessor implements BeanPostProcessor {
     }
     
     private MetaDataRegisterDTO buildMetaDataDTO(final SoulSpringCloudClient soulSpringCloudClient, final String prePath) {
-        String contextPath = this.contextPath;
+        String contextPath = StringUtils.isBlank(this.contextPath) ? this.servletContextPath : this.contextPath;
         String appName = env.getProperty("spring.application.name");
-        String path;
-        if (StringUtils.isEmpty(contextPath)) {
-            path = prePath + soulSpringCloudClient.path();
-        } else {
-            path = contextPath + prePath + soulSpringCloudClient.path();
-        }
+        String path = contextPath + this.servletContextPath + prePath + soulSpringCloudClient.path();
         String host = StringUtils.isBlank(this.host) ? IpUtils.getHost() : this.host;
         int port = StringUtils.isBlank(this.port) ? -1 : Integer.parseInt(this.port);
         String desc = soulSpringCloudClient.desc();


### PR DESCRIPTION

// Describe your PR here; eg. Fixes #issueNo

1: When application.yml config server.servlet.context-path，the rule path does not contains the server.servlet.context-path. So I get fixed it.
2: When soul.client.props.contextPath is null, the path for metadata is "null/**". I get fixed it.

There are four scene:
if the uri for controller is "uri/**", 

case 1: server.servlet.context-path is null, soul.client.props.contextPath is "springCloud"， so the rule path: springCloud/uri/**, the path for metadata is springCloud/**;

case 2: server.servlet.context-path is "app", soul.client.props.contextPath is "springCloud"， so the rule path: springCloud/app/uri/**, the path for metadata is springCloud/**;

case 3: server.servlet.context-path is "app", soul.client.props.contextPath is null， so the rule path: app/app/uri/**, the path for metadata is app/**;

case 3: server.servlet.context-path is null, soul.client.props.contextPath is null， so the rule path: /**, the selector is rule, the path for metadata is /**;

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [ ] You have read the [contribution guidelines](https://dromara.org/projects/soul/contributor/).
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] Your local test passed `mvn clean install -Dmaven.javadoc.skip=true`.
