### PR TITLE
SelectorData add serialVersionUID

### DIFF
--- a/soul-common/src/main/java/org/dromara/soul/common/dto/SelectorData.java
+++ b/soul-common/src/main/java/org/dromara/soul/common/dto/SelectorData.java
@@ -39,6 +39,7 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 public class SelectorData implements Serializable {
+    private static final long serialVersionUID = 760613690421794874L;
 
     private String id;
 


### PR DESCRIPTION
Fixes #1238
Fix the problem in OpenJDK (for example, version 1.8.0_65-b17): Caused by: org.I0Itec.zkclient.exception.ZkMarshallingError: java.io.InvalidClassException: org.dromara.soul.common.dto.SelectorData; local class incompatible: stream classdesc serialVersionUID = 6055627969752212141, local class serialVersionUID = 760613690421794874