### PR TITLE
Add skip ci action script

### DIFF
--- a/.github/actions/skip-ci/action.yml
+++ b/.github/actions/skip-ci/action.yml
@@ -1,0 +1,80 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+name: "Set Skip Env Var"
+description: "Action to set the SKIP_CI environment variable indicating that we should skip CI jobs"
+inputs:
+  ignore-patterns:
+    description: >-
+      Set the SKIP_CI environment variable when and only when all the changed files located in one of the path,
+      the paths is shell-style pattern.
+    required: false
+    default: >-
+      "*.md"
+      "soul-dashboard"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Check Changed Files And Set Env Var
+      shell: bash
+      run: |
+        if [ $GITHUB_BASE_REF ]; then
+          # Pull Request
+          BASE_SHA=$GITHUB_BASE_REF
+        else
+          # Push
+          BASE_SHA=${{ github.event.before }}
+        fi
+
+        echo "Base sha is $BASE_SHA, head sha is $GITHUB_SHA"
+
+        git fetch --no-tags --progress --recurse-submodules --depth=1 origin ${BASE_SHA}:origin/${BASE_SHA}
+        BASE_SHA=origin/${BASE_SHA}
+        echo "Base sha is $BASE_SHA, head sha is $GITHUB_SHA"
+
+        if ! files=$(git --no-pager diff --name-only ${GITHUB_SHA} ${BASE_SHA}); then
+          exit 1
+        fi
+
+        echo "Ignore pattern:"
+        for pattern in $(echo '${{ inputs.ignore-patterns }}'); do
+          echo $pattern
+        done
+
+        echo "Changed files:"
+        for file in ${files}; do
+          echo $file
+        done
+
+        echo "SKIP_CI=true" >> $GITHUB_ENV
+        for file in ${files}; do
+          matched=0
+          for pattern in $(echo '${{ inputs.ignore-patterns }}'); do
+            pattern=$(echo "$pattern" | sed 's/"//g')
+            if eval "[[ '$file' == $pattern ]]"; then
+              matched=1
+              break
+            fi
+          done
+          if [[ "$matched" == "0" ]]; then
+            echo "$file doesn't match pattern $(echo '${{ inputs.ignore-patterns }}'), stop checking"
+            echo "SKIP_CI=false" >> $GITHUB_ENV
+            break
+          fi
+        done

--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -5,13 +5,14 @@ categories:
     labels:
       - 'type: new feature'
       - 'type: enhancement'
+      - 'enhancement'
   - title: 'Bug Fixes'
     labels:
       - 'type: bug'
       - 'bug'
   - title: 'Maintenance'
-    label: 'type: refactor'
-change-template: '- $TITLE (#$NUMBER)'
+    label: 'refactor'
+change-template: '- $TITLE #$NUMBER'
 exclude-labels:
   - 'skip-changelog'
 template: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,9 @@ name: ci
 
 on:
   pull_request:
-    paths-ignore:
-      - "**.md"
   push:
     branches:
       - master
-    paths-ignore:
-      - '**.md'
 
 jobs:
   build:
@@ -32,22 +28,28 @@ jobs:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Cache Maven Repos
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - name: Support longpaths
         if: ${{ matrix.os == 'windows-latest'}}
         run: git config --system core.longpaths true
       - uses: actions/checkout@v2
         with:
           submodules: true
+      - name: Set Skip Env Var
+        uses: ./.github/actions/skip-ci
+      - name: Cache Maven Repos
+        if: env.SKIP_CI != 'true'
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
       - uses: actions/setup-java@v1
+        if: env.SKIP_CI != 'true'
         with:
           java-version: 8
       - name: Build with Maven
+        if: env.SKIP_CI != 'true'
         run: ./mvnw -B clean install
       - uses: codecov/codecov-action@v1
+        if: env.SKIP_CI != 'true'


### PR DESCRIPTION
Currently we simply configure the `paths-ignore` property to skip the workflows. but we make ci action "required" for status check while saving resources for some changes like "*.md". so the committer can't merge pr because of the required status. This patch check the changed files of a pull request and set SKIP_CI to skip the workflows.

reference: [skywalking](https://github.com/apache/skywalking/blob/master/.github/workflows/ci-it.yaml)