### PR TITLE
add plugin intercept enable

### DIFF
--- a/soul-admin/src/main/resources/META-INF/schema.h2.sql
+++ b/soul-admin/src/main/resources/META-INF/schema.h2.sql
@@ -260,6 +260,8 @@ INSERT INTO `soul_dict` (`id`, `type`,`dict_code`, `dict_name`, `dict_value`, `d
 INSERT INTO `soul_dict` (`id`, `type`,`dict_code`, `dict_name`, `dict_value`, `desc`, `sort`, `enabled`, `date_created`, `date_updated`) VALUES ('25', 'multiRuleHandle', 'MULTI_RULE_HANDLE', 'single rule', '0', 'single rule', 0, 1, '2021-03-08 13:39:30', '2021-03-08 13:39:30');
 INSERT INTO `soul_dict` (`id`, `type`,`dict_code`, `dict_name`, `dict_value`, `desc`, `sort`, `enabled`, `date_created`, `date_updated`) VALUES ('26', 'multiSelectorHandle', 'MULTI_SELECTOR_HANDLE', 'multiple handle', '1', 'multiple handle', 1, 1, '2021-03-08 13:26:48', '2021-03-08 13:39:54');
 INSERT INTO `soul_dict` (`id`, `type`,`dict_code`, `dict_name`, `dict_value`, `desc`, `sort`, `enabled`, `date_created`, `date_updated`) VALUES ('27', 'multiSelectorHandle', 'MULTI_SELECTOR_HANDLE', 'single handle', '0', 'single handle', 0, 1, '2021-03-08 13:26:05', '2021-03-08 13:27:54');
+INSERT INTO `soul_dict` (`id`, `type`,`dict_code`, `dict_name`, `dict_value`, `desc`, `sort`, `enabled`, `date_created`, `date_updated`) VALUES ('28', 'interceptEnable', 'INTERCEPT_ENABLE', 'intercept', '1', 'intercept', 0, 1, '2021-03-26 17:32:22', '2021-03-26 17:37:48');
+INSERT INTO `soul_dict` (`id`, `type`,`dict_code`, `dict_name`, `dict_value`, `desc`, `sort`, `enabled`, `date_created`, `date_updated`) VALUES ('29', 'interceptEnable', 'INTERCEPT_ENABLE', 'pass', '0', 'pass', 1, 1, '2021-03-26 17:32:43', '2021-03-26 17:37:52');
 
 /*plugin*/
 INSERT INTO `plugin` (`id`, `name`, `role`, `enabled`, `date_created`, `date_updated`) VALUES ('1','sign','1', '0', '2018-06-14 10:17:35', '2018-06-14 10:17:35');
@@ -291,25 +293,31 @@ INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`
 INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('6','10' ,'degradeRuleGrade','degradeRuleGrade','3', 2, 3, '{"required":"1","defaultValue":"0","rule":""}', '2020-11-09 01:19:10', '2020-11-09 01:19:10');
 INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('7','10' ,'degradeRuleCount','degradeRuleCount','1', 2, 1, '{"required":"1","defaultValue":"0","rule":""}', '2020-11-09 01:19:10', '2020-11-09 01:19:10');
 INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('8','10' ,'degradeRuleTimeWindow','degradeRuleTimeWindow','1', 2, 4, '{"required":"1","defaultValue":"0","rule":""}', '2020-11-09 01:19:10', '2020-11-09 01:19:10');
+INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('80','10','interceptEnable','interceptEnable', '3', 2, 0, '{"required":"1","defaultValue":"1","rule":""}', '2021-03-26 17:28:18', '2021-03-26 17:35:18');
 
 /*insert plugin_handle data for waf*/
 INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`date_created`,`date_updated`) VALUES ('9','2' ,'permission','permission','3', 2, 1, '2020-11-22 12:04:10', '2020-11-22 12:04:10');
 INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`date_created`,`date_updated`) VALUES ('10','2' ,'statusCode','statusCode','2', 2, 2, '2020-11-22 12:04:10', '2020-11-22 12:04:10');
+INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('81','2','interceptEnable','interceptEnable', '3', 2, 0, '{"required":"1","defaultValue":"1","rule":""}', '2021-03-26 17:28:18', '2021-03-26 17:35:18');
 
 /*insert plugin_handle data for rate_limiter*/
 INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('11', '4' ,'replenishRate','replenishRate', 2, 2, 2, '{"required":"1","defaultValue":"10","rule":""}', '2020-11-24 00:17:10', '2020-11-24 00:17:10');
 INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('12', '4' ,'burstCapacity','burstCapacity', 2, 2, 3, '{"required":"1","defaultValue":"100","rule":""}', '2020-11-24 00:17:10', '2020-11-24 00:17:10');
+INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('82','4','interceptEnable','interceptEnable', '3', 2, 0, '{"required":"1","defaultValue":"1","rule":""}', '2021-03-26 17:28:18', '2021-03-26 17:35:18');
 
 /*insert plugin_handle data for rewrite*/
 INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`date_created`,`date_updated`) VALUES ('13', '3' ,'rewriteURI','rewriteURI', 2, 2, 1, '2020-11-29 16:07:10', '2020-11-29 16:07:10');
+INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('83','3','interceptEnable','interceptEnable', '3', 2, 0, '{"required":"1","defaultValue":"1","rule":""}', '2021-03-26 17:28:18', '2021-03-26 17:35:18');
 
 /*insert plugin_handle data for rewrite*/
 INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`date_created`,`date_updated`) VALUES ('42', '16' ,'redirectURI','redirectURI', 2, 2, 1, '2020-11-29 16:07:10', '2020-11-29 16:07:10');
+INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('84','16','interceptEnable','interceptEnable', '3', 2, 0, '{"required":"1","defaultValue":"1","rule":""}', '2021-03-26 17:28:18', '2021-03-26 17:35:18');
 
 /*insert plugin_handle data for springCloud*/
 INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`date_created`,`date_updated`) VALUES ('14', '8' ,'path','path', 2, 2, 1, '2020-11-29 16:07:10', '2020-11-29 16:07:10');
 INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`date_created`,`date_updated`) VALUES ('15', '8' ,'timeout','timeout (ms)', 1, 2, 2, '2020-11-29 16:07:10', '2020-11-29 16:07:10');
 INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`date_created`,`date_updated`) VALUES ('16', '8' ,'serviceId','serviceId', 2, 1, 1, '2020-11-29 16:07:10', '2020-11-29 16:07:10');
+INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('85','8','interceptEnable','interceptEnable', '3', 2, 0, '{"required":"1","defaultValue":"1","rule":""}', '2021-03-26 17:28:18', '2021-03-26 17:35:18');
 
 /*insert plugin_handle data for resilience4j*/
 INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('17', '12' ,'timeoutDurationRate','timeoutDurationRate (ms)', 1, 2, 1, '{"required":"1","defaultValue":"5000","rule":""}', '2020-11-28 11:08:14', '2020-11-28 11:19:12');
@@ -324,6 +332,7 @@ INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`
 INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('26', '12' ,'waitIntervalFunctionInOpenState','waitIntervalInOpen', 1, 2, 2, '{"required":"1","defaultValue":"60000","rule":""}', '2020-11-28 11:29:01', '2020-11-28 11:29:01');
 INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('27', '12' ,'permittedNumberOfCallsInHalfOpenState','bufferSizeInHalfOpen', 1, 2, 2, '{"required":"1","defaultValue":"10","rule":""}', '2020-11-28 11:29:55', '2020-11-28 11:29:55');
 INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('28', '12' ,'failureRateThreshold','failureRateThreshold', 1, 2, 2, '{"required":"1","defaultValue":"50","rule":""}', '2020-11-28 11:30:40', '2020-11-28 11:30:40');
+INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('86','12','interceptEnable','interceptEnable', '3', 2, 0, '{"required":"1","defaultValue":"1","rule":""}', '2021-03-26 17:28:18', '2021-03-26 17:35:18');
 
 /*insert plugin_handle data for plugin*/
 INSERT INTO plugin_handle (`id`, `plugin_id`, `field`, `label`, `data_type`, `type`, `sort`, `ext_obj`, `date_created`, `date_updated`) VALUES ('30', '4', 'mode', 'mode', 3, 3, 1, NULL, '2020-12-25 00:00:00', '2020-12-25 00:00:00');
@@ -338,6 +347,8 @@ INSERT INTO plugin_handle (`id`, `plugin_id`, `field`, `label`, `data_type`, `ty
 INSERT INTO plugin_handle (`id`, `plugin_id`, `field`, `label`, `data_type`, `type`, `sort`, `ext_obj`, `date_created`, `date_updated`) VALUES ('39', '7', 'host', 'host', 2, 3, 2, NULL, '2020-12-25 00:00:00', '2020-12-25 00:00:00');
 INSERT INTO plugin_handle (`id`, `plugin_id`, `field`, `label`, `data_type`, `type`, `sort`, `ext_obj`, `date_created`, `date_updated`) VALUES ('40', '7', 'port', 'port', 2, 3, 3, '{"rule":"/^[0-9]*$/"}', '2020-12-25 00:00:00', '2020-12-25 00:00:00');
 INSERT INTO plugin_handle (`id`, `plugin_id`, `field`, `label`, `data_type`, `type`, `sort`, `ext_obj`, `date_created`, `date_updated`) VALUES ('41', '7', 'async', 'async', 2, 3, 4, NULL, '2020-12-25 00:00:00', '2020-12-25 00:00:00');
+INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('87','7','interceptEnable','interceptEnable', '3', 2, 0, '{"required":"1","defaultValue":"1","rule":""}', '2021-03-26 17:28:18', '2021-03-26 17:35:18');
+
 /*insert plugin_handle data for plugin rate_limiter*/
 INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('43','4' ,'algorithmName','algorithmName','3', 2, 1, '{"required":"1","defaultValue":"slidingWindow","rule":""}', '2020-11-09 01:19:10', '2020-11-09 01:19:10');
 
@@ -348,6 +359,7 @@ INSERT INTO soul_dict (`id`, `type`, `dict_code`, `dict_name`, `dict_value`, `de
 
 /*insert plugin_handle data for context path*/
 INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`date_created`,`date_updated`) VALUES ('29', '14', 'contextPath', 'contextPath', 2, 2, 0, '2020-12-25 16:13:09', '2020-12-25 16:13:09');
+INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('88','14','interceptEnable','interceptEnable', '3', 2, 0, '{"required":"1","defaultValue":"1","rule":""}', '2021-03-26 17:28:18', '2021-03-26 17:35:18');
 
 /*insert plugin_handle data for divide*/
 INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('44', '5', 'upstreamHost', 'host', 2, 1, 0, null, '2021-03-06 21:23:41', '2021-03-09 10:32:51');
@@ -362,6 +374,7 @@ INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`
 INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('53', '5', 'timeout', 'timeout', 1, 2, 2, '{"defaultValue":"3000","rule":""}', '2021-03-07 21:13:50', '2021-03-09 10:32:51');
 INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('54', '5', 'multiSelectorHandle', 'multiSelectorHandle', 3, 3, 0, null, '2021-03-08 13:18:44', '2021-03-09 10:32:51');
 INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('55', '5', 'multiRuleHandle', 'multiRuleHandle', 3, 3, 1, null, '2021-03-08 13:37:12', '2021-03-09 10:32:51');
+INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('89','5','interceptEnable','interceptEnable', '3', 2, 0, '{"required":"1","defaultValue":"1","rule":""}', '2021-03-26 17:28:18', '2021-03-26 17:35:18');
 
 /*insert plugin_handle data for tars*/
 INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('56', '13', 'upstreamHost', 'host', 2, 1, 0, null, '2021-03-06 21:23:41', '2021-03-09 10:32:51');
@@ -376,6 +389,7 @@ INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`
 INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('65', '13', 'timeout', 'timeout', 1, 2, 2, '{"defaultValue":"3000","rule":""}', '2021-03-07 21:13:50', '2021-03-09 10:32:51');
 INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('66', '13', 'multiSelectorHandle', 'multiSelectorHandle', 3, 3, 0, null, '2021-03-08 13:18:44', '2021-03-09 10:32:51');
 INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('67', '13', 'multiRuleHandle', 'multiRuleHandle', 3, 3, 1, null, '2021-03-08 13:37:12', '2021-03-09 10:32:51');
+INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('90','13','interceptEnable','interceptEnable', '3', 2, 0, '{"required":"1","defaultValue":"1","rule":""}', '2021-03-26 17:28:18', '2021-03-26 17:35:18');
 
 /*insert plugin_handle data for grpc*/
 INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('69', '15', 'protocol', 'protocol', 2, 1, 2, '{"defaultValue":"","rule":""}', '2021-03-06 21:25:37', '2021-03-09 10:32:51');
@@ -384,6 +398,12 @@ INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`
 INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('74', '15', 'status', 'status', 3, 1, 6, '{"defaultValue":"true","rule":""}', '2021-03-06 21:29:16', '2021-03-09 10:32:51');
 INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('78', '15', 'multiSelectorHandle', 'multiSelectorHandle', 3, 3, 0, null, '2021-03-08 13:18:44', '2021-03-09 10:32:51');
 INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('79', '15', 'multiRuleHandle', 'multiRuleHandle', 3, 3, 1, null, '2021-03-08 13:37:12', '2021-03-09 10:32:51');
+INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('91','15','interceptEnable','interceptEnable', '3', 2, 0, '{"required":"1","defaultValue":"1","rule":""}', '2021-03-26 17:28:18', '2021-03-26 17:35:18');
+
+INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('92','1','interceptEnable','interceptEnable', '3', 2, 0, '{"required":"1","defaultValue":"1","rule":""}', '2021-03-26 17:28:18', '2021-03-26 17:35:18');
+INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('93','6','interceptEnable','interceptEnable', '3', 2, 0, '{"required":"1","defaultValue":"1","rule":""}', '2021-03-26 17:28:18', '2021-03-26 17:35:18');
+INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('94','9','interceptEnable','interceptEnable', '3', 2, 0, '{"required":"1","defaultValue":"1","rule":""}', '2021-03-26 17:28:18', '2021-03-26 17:35:18');
+INSERT INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('95','11','interceptEnable','interceptEnable', '3', 2, 0, '{"required":"1","defaultValue":"1","rule":""}', '2021-03-26 17:28:18', '2021-03-26 17:35:18');
 
 /** insert permission role for role */
 INSERT INTO `role` (`id`,`role_name`,`description`,`date_created`,`date_updated`) VALUES ('1346358560427216896', 'super', '超级管理员', '2021-01-05 01:31:10', '2021-01-08 17:00:07');

--- a/soul-admin/src/main/resources/META-INF/schema.sql
+++ b/soul-admin/src/main/resources/META-INF/schema.sql
@@ -263,6 +263,8 @@ INSERT IGNORE INTO `soul_dict` (`id`, `type`,`dict_code`, `dict_name`, `dict_val
 INSERT IGNORE INTO `soul_dict` (`id`, `type`,`dict_code`, `dict_name`, `dict_value`, `desc`, `sort`, `enabled`, `date_created`, `date_updated`) VALUES ('25', 'multiRuleHandle', 'MULTI_RULE_HANDLE', 'single rule', '0', 'single rule', 0, 1, '2021-03-08 13:39:30', '2021-03-08 13:39:30');
 INSERT IGNORE INTO `soul_dict` (`id`, `type`,`dict_code`, `dict_name`, `dict_value`, `desc`, `sort`, `enabled`, `date_created`, `date_updated`) VALUES ('26', 'multiSelectorHandle', 'MULTI_SELECTOR_HANDLE', 'multiple handle', '1', 'multiple handle', 1, 1, '2021-03-08 13:26:48', '2021-03-08 13:39:54');
 INSERT IGNORE INTO `soul_dict` (`id`, `type`,`dict_code`, `dict_name`, `dict_value`, `desc`, `sort`, `enabled`, `date_created`, `date_updated`) VALUES ('27', 'multiSelectorHandle', 'MULTI_SELECTOR_HANDLE', 'single handle', '0', 'single handle', 0, 1, '2021-03-08 13:26:05', '2021-03-08 13:27:54');
+INSERT IGNORE INTO `soul_dict` (`id`, `type`,`dict_code`, `dict_name`, `dict_value`, `desc`, `sort`, `enabled`, `date_created`, `date_updated`) VALUES ('28', 'interceptEnable', 'INTERCEPT_ENABLE', 'intercept', '1', 'intercept', 0, 1, '2021-03-26 17:32:22', '2021-03-26 17:37:48');
+INSERT IGNORE INTO `soul_dict` (`id`, `type`,`dict_code`, `dict_name`, `dict_value`, `desc`, `sort`, `enabled`, `date_created`, `date_updated`) VALUES ('29', 'interceptEnable', 'INTERCEPT_ENABLE', 'pass', '0', 'pass', 1, 1, '2021-03-26 17:32:43', '2021-03-26 17:37:52');
 
 /*plugin*/
 INSERT IGNORE INTO `plugin` (`id`, `name`, `role`, `enabled`, `date_created`, `date_updated`) VALUES ('1','sign','1', '0', '2018-06-14 10:17:35', '2018-06-14 10:17:35');
@@ -294,25 +296,31 @@ INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`
 INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('6','10' ,'degradeRuleGrade','degradeRuleGrade','3', 2, 3, '{"required":"1","defaultValue":"0","rule":""}', '2020-11-09 01:19:10', '2020-11-09 01:19:10');
 INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('7','10' ,'degradeRuleCount','degradeRuleCount','1', 2, 1, '{"required":"1","defaultValue":"0","rule":""}', '2020-11-09 01:19:10', '2020-11-09 01:19:10');
 INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('8','10' ,'degradeRuleTimeWindow','degradeRuleTimeWindow','1', 2, 4, '{"required":"1","defaultValue":"0","rule":""}', '2020-11-09 01:19:10', '2020-11-09 01:19:10');
+INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('80','10','interceptEnable','interceptEnable', '3', 2, 0, '{"required":"1","defaultValue":"1","rule":""}', '2021-03-26 17:28:18', '2021-03-26 17:35:18');
 
 /*insert plugin_handle data for waf*/
 INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`date_created`,`date_updated`) VALUES ('9','2' ,'permission','permission','3', 2, 1, '2020-11-22 12:04:10', '2020-11-22 12:04:10');
 INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`date_created`,`date_updated`) VALUES ('10','2' ,'statusCode','statusCode','2', 2, 2, '2020-11-22 12:04:10', '2020-11-22 12:04:10');
+INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('81','2','interceptEnable','interceptEnable', '3', 2, 0, '{"required":"1","defaultValue":"1","rule":""}', '2021-03-26 17:28:18', '2021-03-26 17:35:18');
 
 /*insert plugin_handle data for rate_limiter*/
 INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('11', '4' ,'replenishRate','replenishRate', 2, 2, 2, '{"required":"1","defaultValue":"10","rule":""}', '2020-11-24 00:17:10', '2020-11-24 00:17:10');
 INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('12', '4' ,'burstCapacity','burstCapacity', 2, 2, 3, '{"required":"1","defaultValue":"100","rule":""}', '2020-11-24 00:17:10', '2020-11-24 00:17:10');
+INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('82','4','interceptEnable','interceptEnable', '3', 2, 0, '{"required":"1","defaultValue":"1","rule":""}', '2021-03-26 17:28:18', '2021-03-26 17:35:18');
 
 /*insert plugin_handle data for rewrite*/
 INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`date_created`,`date_updated`) VALUES ('13', '3' ,'rewriteURI','rewriteURI', 2, 2, 1, '2020-11-29 16:07:10', '2020-11-29 16:07:10');
+INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('83','3','interceptEnable','interceptEnable', '3', 2, 0, '{"required":"1","defaultValue":"1","rule":""}', '2021-03-26 17:28:18', '2021-03-26 17:35:18');
 
 /*insert plugin_handle data for rewrite*/
 INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`date_created`,`date_updated`) VALUES ('42', '16' ,'redirectURI','redirectURI', 2, 2, 1, '2020-11-29 16:07:10', '2020-11-29 16:07:10');
+INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('84','16','interceptEnable','interceptEnable', '3', 2, 0, '{"required":"1","defaultValue":"1","rule":""}', '2021-03-26 17:28:18', '2021-03-26 17:35:18');
 
 /*insert plugin_handle data for springCloud*/
 INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`date_created`,`date_updated`) VALUES ('14', '8' ,'path','path', 2, 2, 1, '2020-11-29 16:07:10', '2020-11-29 16:07:10');
 INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`date_created`,`date_updated`) VALUES ('15', '8' ,'timeout','timeout (ms)', 1, 2, 2, '2020-11-29 16:07:10', '2020-11-29 16:07:10');
 INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`date_created`,`date_updated`) VALUES ('16', '8' ,'serviceId','serviceId', 2, 1, 1, '2020-11-29 16:07:10', '2020-11-29 16:07:10');
+INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('85','8','interceptEnable','interceptEnable', '3', 2, 0, '{"required":"1","defaultValue":"1","rule":""}', '2021-03-26 17:28:18', '2021-03-26 17:35:18');
 
 /*insert plugin_handle data for resilience4j*/
 INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('17', '12' ,'timeoutDurationRate','timeoutDurationRate (ms)', 1, 2, 1, '{"required":"1","defaultValue":"5000","rule":""}', '2020-11-28 11:08:14', '2020-11-28 11:19:12');
@@ -327,6 +335,7 @@ INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`
 INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('26', '12' ,'waitIntervalFunctionInOpenState','waitIntervalInOpen', 1, 2, 2, '{"required":"1","defaultValue":"60000","rule":""}', '2020-11-28 11:29:01', '2020-11-28 11:29:01');
 INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('27', '12' ,'permittedNumberOfCallsInHalfOpenState','bufferSizeInHalfOpen', 1, 2, 2, '{"required":"1","defaultValue":"10","rule":""}', '2020-11-28 11:29:55', '2020-11-28 11:29:55');
 INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('28', '12' ,'failureRateThreshold','failureRateThreshold', 1, 2, 2, '{"required":"1","defaultValue":"50","rule":""}', '2020-11-28 11:30:40', '2020-11-28 11:30:40');
+INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('86','12','interceptEnable','interceptEnable', '3', 2, 0, '{"required":"1","defaultValue":"1","rule":""}', '2021-03-26 17:28:18', '2021-03-26 17:35:18');
 
 /*insert plugin_handle data for plugin*/
 INSERT IGNORE INTO plugin_handle (`id`, `plugin_id`, `field`, `label`, `data_type`, `type`, `sort`, `ext_obj`, `date_created`, `date_updated`) VALUES ('30', '4', 'mode', 'mode', 3, 3, 1, NULL, '2020-12-25 00:00:00', '2020-12-25 00:00:00');
@@ -341,6 +350,8 @@ INSERT IGNORE INTO plugin_handle (`id`, `plugin_id`, `field`, `label`, `data_typ
 INSERT IGNORE INTO plugin_handle (`id`, `plugin_id`, `field`, `label`, `data_type`, `type`, `sort`, `ext_obj`, `date_created`, `date_updated`) VALUES ('39', '7', 'host', 'host', 2, 3, 2, NULL, '2020-12-25 00:00:00', '2020-12-25 00:00:00');
 INSERT IGNORE INTO plugin_handle (`id`, `plugin_id`, `field`, `label`, `data_type`, `type`, `sort`, `ext_obj`, `date_created`, `date_updated`) VALUES ('40', '7', 'port', 'port', 2, 3, 3, '{"rule":"/^[0-9]*$/"}', '2020-12-25 00:00:00', '2020-12-25 00:00:00');
 INSERT IGNORE INTO plugin_handle (`id`, `plugin_id`, `field`, `label`, `data_type`, `type`, `sort`, `ext_obj`, `date_created`, `date_updated`) VALUES ('41', '7', 'async', 'async', 2, 3, 4, NULL, '2020-12-25 00:00:00', '2020-12-25 00:00:00');
+INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('87','7','interceptEnable','interceptEnable', '3', 2, 0, '{"required":"1","defaultValue":"1","rule":""}', '2021-03-26 17:28:18', '2021-03-26 17:35:18');
+
 /*insert plugin_handle data for plugin rate_limiter*/
 INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('43','4' ,'algorithmName','algorithmName','3', 2, 1, '{"required":"1","defaultValue":"slidingWindow","rule":""}', '2020-11-09 01:19:10', '2020-11-09 01:19:10');
 
@@ -351,6 +362,7 @@ INSERT IGNORE INTO soul_dict (`id`, `type`, `dict_code`, `dict_name`, `dict_valu
 
 /*insert plugin_handle data for context path*/
 INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`date_created`,`date_updated`) VALUES ('29', '14', 'contextPath', 'contextPath', 2, 2, 0, '2020-12-25 16:13:09', '2020-12-25 16:13:09');
+INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('88','14','interceptEnable','interceptEnable', '3', 2, 0, '{"required":"1","defaultValue":"1","rule":""}', '2021-03-26 17:28:18', '2021-03-26 17:35:18');
 
 /*insert plugin_handle data for divide*/
 INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('44', '5', 'upstreamHost', 'host', 2, 1, 0, null, '2021-03-06 21:23:41', '2021-03-09 10:32:51');
@@ -365,6 +377,7 @@ INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`
 INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('53', '5', 'timeout', 'timeout', 1, 2, 2, '{"defaultValue":"3000","rule":""}', '2021-03-07 21:13:50', '2021-03-09 10:32:51');
 INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('54', '5', 'multiSelectorHandle', 'multiSelectorHandle', 3, 3, 0, null, '2021-03-08 13:18:44', '2021-03-09 10:32:51');
 INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('55', '5', 'multiRuleHandle', 'multiRuleHandle', 3, 3, 1, null, '2021-03-08 13:37:12', '2021-03-09 10:32:51');
+INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('89','5','interceptEnable','interceptEnable', '3', 2, 0, '{"required":"1","defaultValue":"1","rule":""}', '2021-03-26 17:28:18', '2021-03-26 17:35:18');
 
 /*insert plugin_handle data for tars*/
 INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('56', '13', 'upstreamHost', 'host', 2, 1, 0, null, '2021-03-06 21:23:41', '2021-03-09 10:32:51');
@@ -379,13 +392,21 @@ INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`
 INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('65', '13', 'timeout', 'timeout', 1, 2, 2, '{"defaultValue":"3000","rule":""}', '2021-03-07 21:13:50', '2021-03-09 10:32:51');
 INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('66', '13', 'multiSelectorHandle', 'multiSelectorHandle', 3, 3, 0, null, '2021-03-08 13:18:44', '2021-03-09 10:32:51');
 INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('67', '13', 'multiRuleHandle', 'multiRuleHandle', 3, 3, 1, null, '2021-03-08 13:37:12', '2021-03-09 10:32:51');
+INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('90','13','interceptEnable','interceptEnable', '3', 2, 0, '{"required":"1","defaultValue":"1","rule":""}', '2021-03-26 17:28:18', '2021-03-26 17:35:18');
 
 /*insert plugin_handle data for grpc*/
+INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('69', '15', 'protocol', 'protocol', 2, 1, 2, '{"defaultValue":"","rule":""}', '2021-03-06 21:25:37', '2021-03-09 10:32:51');
 INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('70', '15', 'upstreamUrl', 'ip:port', 2, 1, 1, '{"required":"1","placeholder":"","rule":""}', '2021-03-06 21:25:55', '2021-03-09 10:32:51');
 INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('71', '15', 'weight', 'weight', 1, 1, 3, '{"defaultValue":"50","rule":""}', '2021-03-06 21:26:35', '2021-03-09 10:32:51');
 INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('74', '15', 'status', 'status', 3, 1, 6, '{"defaultValue":"true","rule":""}', '2021-03-06 21:29:16', '2021-03-09 10:32:51');
 INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('78', '15', 'multiSelectorHandle', 'multiSelectorHandle', 3, 3, 0, null, '2021-03-08 13:18:44', '2021-03-09 10:32:51');
 INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('79', '15', 'multiRuleHandle', 'multiRuleHandle', 3, 3, 1, null, '2021-03-08 13:37:12', '2021-03-09 10:32:51');
+INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('91','15','interceptEnable','interceptEnable', '3', 2, 0, '{"required":"1","defaultValue":"1","rule":""}', '2021-03-26 17:28:18', '2021-03-26 17:35:18');
+
+INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('92','1','interceptEnable','interceptEnable', '3', 2, 0, '{"required":"1","defaultValue":"1","rule":""}', '2021-03-26 17:28:18', '2021-03-26 17:35:18');
+INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('93','6','interceptEnable','interceptEnable', '3', 2, 0, '{"required":"1","defaultValue":"1","rule":""}', '2021-03-26 17:28:18', '2021-03-26 17:35:18');
+INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('94','9','interceptEnable','interceptEnable', '3', 2, 0, '{"required":"1","defaultValue":"1","rule":""}', '2021-03-26 17:28:18', '2021-03-26 17:35:18');
+INSERT IGNORE INTO plugin_handle (`id`,`plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`,`date_created`,`date_updated`) VALUES ('95','11','interceptEnable','interceptEnable', '3', 2, 0, '{"required":"1","defaultValue":"1","rule":""}', '2021-03-26 17:28:18', '2021-03-26 17:35:18');
 
 /** insert permission role for role */
 INSERT IGNORE INTO `role` (`id`,`role_name`,`description`,`date_created`,`date_updated`) VALUES ('1346358560427216896', 'super', '超级管理员', '2021-01-05 01:31:10', '2021-01-08 17:00:07');

--- a/soul-common/src/main/java/org/dromara/soul/common/constant/Constants.java
+++ b/soul-common/src/main/java/org/dromara/soul/common/constant/Constants.java
@@ -473,6 +473,11 @@ public interface Constants {
     String SCHEDULED_TIME_VALUE = "10";
 
     /**
+     * default intercept enable value.
+     */
+    String DEFAULT_INTERCEPT_ENABLE_VALUE = "1";
+
+    /**
      * String q.
      */
     default void findConstants() {

--- a/soul-common/src/main/java/org/dromara/soul/common/dto/convert/HystrixHandle.java
+++ b/soul-common/src/main/java/org/dromara/soul/common/dto/convert/HystrixHandle.java
@@ -21,6 +21,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import org.dromara.soul.common.constant.Constants;
+import org.dromara.soul.common.dto.convert.rule.BaseRuleHandle;
 import org.dromara.soul.common.enums.HystrixIsolationModeEnum;
 
 /**
@@ -31,7 +32,7 @@ import org.dromara.soul.common.enums.HystrixIsolationModeEnum;
 @Getter
 @Setter
 @EqualsAndHashCode
-public class HystrixHandle {
+public class HystrixHandle extends BaseRuleHandle {
 
     /**
      * hystrix group key is required.

--- a/soul-common/src/main/java/org/dromara/soul/common/dto/convert/RateLimiterHandle.java
+++ b/soul-common/src/main/java/org/dromara/soul/common/dto/convert/RateLimiterHandle.java
@@ -18,6 +18,7 @@
 package org.dromara.soul.common.dto.convert;
 
 import lombok.Data;
+import org.dromara.soul.common.dto.convert.rule.BaseRuleHandle;
 
 /**
  * this is rateLimiter plugin handle.
@@ -25,8 +26,8 @@ import lombok.Data;
  * @author xiaoyu(Myth)
  */
 @Data
-public class RateLimiterHandle {
-    
+public class RateLimiterHandle extends BaseRuleHandle {
+
     /**
      * algorithm name.
      */
@@ -41,7 +42,7 @@ public class RateLimiterHandle {
      * burst capacity.
      */
     private double burstCapacity;
-    
+
     /**
      * request count.
      */

--- a/soul-common/src/main/java/org/dromara/soul/common/dto/convert/RedirectHandle.java
+++ b/soul-common/src/main/java/org/dromara/soul/common/dto/convert/RedirectHandle.java
@@ -18,6 +18,7 @@
 package org.dromara.soul.common.dto.convert;
 
 import lombok.Data;
+import org.dromara.soul.common.dto.convert.rule.BaseRuleHandle;
 
 /**
  * This is redirect plugin handle.
@@ -25,7 +26,7 @@ import lombok.Data;
  * @author HoldDie
  */
 @Data
-public class RedirectHandle {
+public class RedirectHandle extends BaseRuleHandle {
     /**
      * redirect url.
      */

--- a/soul-common/src/main/java/org/dromara/soul/common/dto/convert/Resilience4JHandle.java
+++ b/soul-common/src/main/java/org/dromara/soul/common/dto/convert/Resilience4JHandle.java
@@ -20,6 +20,7 @@ package org.dromara.soul.common.dto.convert;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.dromara.soul.common.constant.Constants;
+import org.dromara.soul.common.dto.convert.rule.BaseRuleHandle;
 
 /**
  * this is Resilience4J plugin handle.
@@ -28,7 +29,7 @@ import org.dromara.soul.common.constant.Constants;
  */
 @Data
 @EqualsAndHashCode
-public class Resilience4JHandle {
+public class Resilience4JHandle extends BaseRuleHandle {
 
     /**
      * ratelimiter timeoutDurationRate.

--- a/soul-common/src/main/java/org/dromara/soul/common/dto/convert/RewriteHandle.java
+++ b/soul-common/src/main/java/org/dromara/soul/common/dto/convert/RewriteHandle.java
@@ -18,13 +18,14 @@
 package org.dromara.soul.common.dto.convert;
 
 import lombok.Data;
+import org.dromara.soul.common.dto.convert.rule.BaseRuleHandle;
 
 /**
  * this is rewrite plugin handle.
  * @author xiaoyu
  */
 @Data
-public class RewriteHandle {
+public class RewriteHandle extends BaseRuleHandle {
 
     /**
      * rewrite uri.

--- a/soul-common/src/main/java/org/dromara/soul/common/dto/convert/SentinelHandle.java
+++ b/soul-common/src/main/java/org/dromara/soul/common/dto/convert/SentinelHandle.java
@@ -21,6 +21,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import org.dromara.soul.common.constant.Constants;
+import org.dromara.soul.common.dto.convert.rule.BaseRuleHandle;
 
 /**
  * This is SentinelHandle.
@@ -30,7 +31,7 @@ import org.dromara.soul.common.constant.Constants;
 @Getter
 @Setter
 @EqualsAndHashCode
-public class SentinelHandle {
+public class SentinelHandle extends BaseRuleHandle {
 
     /**
      * Flow rule enable.

--- a/soul-common/src/main/java/org/dromara/soul/common/dto/convert/WafHandle.java
+++ b/soul-common/src/main/java/org/dromara/soul/common/dto/convert/WafHandle.java
@@ -18,6 +18,7 @@
 package org.dromara.soul.common.dto.convert;
 
 import lombok.Data;
+import org.dromara.soul.common.dto.convert.rule.BaseRuleHandle;
 
 /**
  * this is waf plugin handle.
@@ -25,7 +26,7 @@ import lombok.Data;
  * @author xiaoyu
  */
 @Data
-public class WafHandle {
+public class WafHandle extends BaseRuleHandle {
 
     /**
      * permission.

--- a/soul-common/src/main/java/org/dromara/soul/common/dto/convert/rule/BaseRuleHandle.java
+++ b/soul-common/src/main/java/org/dromara/soul/common/dto/convert/rule/BaseRuleHandle.java
@@ -15,42 +15,30 @@
  * limitations under the License.
  */
 
-package org.dromara.soul.common.dto.convert.rule.impl;
+package org.dromara.soul.common.dto.convert.rule;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.Data;
 import org.dromara.soul.common.constant.Constants;
-import org.dromara.soul.common.dto.convert.rule.BaseRuleHandle;
-import org.dromara.soul.common.dto.convert.rule.RuleHandle;
 
 /**
- * The type Spring cloud rule handle.
+ * this is base handle.
  *
- * @author xiaoyu(Myth)
+ * @author Naah
  */
-@ToString
-@Getter
-@Setter
-@NoArgsConstructor
-public class SpringCloudRuleHandle extends BaseRuleHandle implements RuleHandle {
-
-    private static final long serialVersionUID = 269429745060607954L;
+@Data
+public class BaseRuleHandle {
 
     /**
-     * this remote uri path.
+     * intercept enable.
      */
-    private String path;
+    private String interceptEnable = Constants.DEFAULT_INTERCEPT_ENABLE_VALUE;
 
     /**
-     * timeout is required.
+     * rule intercept status.
+     *
+     * @return boolean of intercept status
      */
-    private long timeout = Constants.TIME_OUT;
-
-    @Override
-    public RuleHandle createDefault(final String path) {
-        this.path = path;
-        return this;
+    public boolean isIntercepted() {
+        return Constants.DEFAULT_INTERCEPT_ENABLE_VALUE.equals(this.interceptEnable);
     }
 }

--- a/soul-common/src/main/java/org/dromara/soul/common/dto/convert/rule/impl/ContextMappingHandle.java
+++ b/soul-common/src/main/java/org/dromara/soul/common/dto/convert/rule/impl/ContextMappingHandle.java
@@ -19,6 +19,7 @@ package org.dromara.soul.common.dto.convert.rule.impl;
 
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.dromara.soul.common.dto.convert.rule.BaseRuleHandle;
 import org.dromara.soul.common.dto.convert.rule.RuleHandle;
 
 /**
@@ -28,7 +29,7 @@ import org.dromara.soul.common.dto.convert.rule.RuleHandle;
  */
 @Data
 @NoArgsConstructor
-public class ContextMappingHandle implements RuleHandle {
+public class ContextMappingHandle extends BaseRuleHandle implements RuleHandle {
 
     private static final long serialVersionUID = 4891655505357494670L;
 

--- a/soul-common/src/main/java/org/dromara/soul/common/dto/convert/rule/impl/DivideRuleHandle.java
+++ b/soul-common/src/main/java/org/dromara/soul/common/dto/convert/rule/impl/DivideRuleHandle.java
@@ -21,6 +21,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.dromara.soul.common.constant.Constants;
 import org.dromara.soul.common.constant.RuleHandleConstants;
+import org.dromara.soul.common.dto.convert.rule.BaseRuleHandle;
 import org.dromara.soul.common.dto.convert.rule.RuleHandle;
 
 /**
@@ -30,7 +31,7 @@ import org.dromara.soul.common.dto.convert.rule.RuleHandle;
  */
 @Data
 @NoArgsConstructor
-public class DivideRuleHandle implements RuleHandle {
+public class DivideRuleHandle extends BaseRuleHandle implements RuleHandle {
 
     private static final long serialVersionUID = 3975134663460754084L;
 

--- a/soul-common/src/main/java/org/dromara/soul/common/dto/convert/rule/impl/DubboRuleHandle.java
+++ b/soul-common/src/main/java/org/dromara/soul/common/dto/convert/rule/impl/DubboRuleHandle.java
@@ -23,6 +23,7 @@ import lombok.Setter;
 import lombok.ToString;
 import org.dromara.soul.common.constant.Constants;
 import org.dromara.soul.common.constant.RuleHandleConstants;
+import org.dromara.soul.common.dto.convert.rule.BaseRuleHandle;
 import org.dromara.soul.common.dto.convert.rule.RuleHandle;
 
 /**
@@ -34,7 +35,7 @@ import org.dromara.soul.common.dto.convert.rule.RuleHandle;
 @Setter
 @ToString
 @NoArgsConstructor
-public class DubboRuleHandle implements RuleHandle {
+public class DubboRuleHandle extends BaseRuleHandle implements RuleHandle {
 
     private static final long serialVersionUID = 2687375375638048966L;
 

--- a/soul-common/src/main/java/org/dromara/soul/common/dto/convert/rule/impl/SofaRuleHandle.java
+++ b/soul-common/src/main/java/org/dromara/soul/common/dto/convert/rule/impl/SofaRuleHandle.java
@@ -23,6 +23,7 @@ import lombok.Setter;
 import lombok.ToString;
 import org.dromara.soul.common.constant.Constants;
 import org.dromara.soul.common.constant.RuleHandleConstants;
+import org.dromara.soul.common.dto.convert.rule.BaseRuleHandle;
 import org.dromara.soul.common.dto.convert.rule.RuleHandle;
 
 /**
@@ -34,7 +35,7 @@ import org.dromara.soul.common.dto.convert.rule.RuleHandle;
 @Setter
 @ToString
 @NoArgsConstructor
-public class SofaRuleHandle implements RuleHandle {
+public class SofaRuleHandle extends BaseRuleHandle implements RuleHandle {
 
     private static final long serialVersionUID = 1534867207078368915L;
 

--- a/soul-plugin/soul-plugin-base/src/main/java/org/dromara/soul/plugin/base/AbstractSoulPlugin.java
+++ b/soul-plugin/soul-plugin-base/src/main/java/org/dromara/soul/plugin/base/AbstractSoulPlugin.java
@@ -20,6 +20,7 @@ package org.dromara.soul.plugin.base;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,7 +28,9 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.dromara.soul.common.dto.SelectorData;
 import org.dromara.soul.common.dto.RuleData;
 import org.dromara.soul.common.dto.PluginData;
+import org.dromara.soul.common.dto.convert.rule.BaseRuleHandle;
 import org.dromara.soul.common.enums.SelectorTypeEnum;
+import org.dromara.soul.common.utils.GsonUtils;
 import org.dromara.soul.plugin.api.SoulPlugin;
 import org.dromara.soul.plugin.api.SoulPluginChain;
 import org.dromara.soul.plugin.base.cache.BaseDataCache;
@@ -92,7 +95,12 @@ public abstract class AbstractSoulPlugin implements SoulPlugin {
                 return handleRuleIsNull(pluginName, exchange, chain);
             }
             ruleLog(rule, pluginName);
-            return doExecute(exchange, chain, selectorData, rule);
+            BaseRuleHandle baseRuleHandle = GsonUtils.getInstance().fromJson(Optional.ofNullable(rule.getHandle()).orElse("{}"), BaseRuleHandle.class);
+            if (baseRuleHandle.isIntercepted()) {
+                return doExecute(exchange, chain, selectorData, rule);
+            } else {
+                return chain.execute(exchange);
+            }
         }
         return chain.execute(exchange);
     }


### PR DESCRIPTION
issue #1198 @tuohai666 

1. add base class  named `BaseRuleHandle` of all plugin rule handle. default of `interceptEnable` in `BaseRuleHandle` is intercept.
2. add `plugin_handle` to all plugin  in sql `schema.sql`
3. add judge intercept logic in `AbstractSoulPlugin#execute:98`


Make sure that:

- [x] You have read the [contribution guidelines](https://dromara.org/projects/soul/contributor/).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `mvn clean install -Dmaven.javadoc.skip=true`.
