### PR TITLE
Remove soul-dashboard submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "soul-dashboard"]
-	path = soul-dashboard
-	url = https://github.com/dromara/soul-dashboard.git

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,6 @@
         <mapstruct.version>1.3.1.Final</mapstruct.version>
         <prometheus-java-client.version>0.10.0</prometheus-java-client.version>
         <prometheus-jmx.version>0.15.0</prometheus-jmx.version>
-        <frontend.plugin.skip>true</frontend.plugin.skip>
         <swagger.version>2.9.2</swagger.version>
         <sofa.rpc.version>5.7.6</sofa.rpc.version>
         <tars.version>1.7.2</tars.version>
@@ -363,7 +362,7 @@
                 <artifactId>nacos-client</artifactId>
                 <version>${nacos-client.version}</version>
             </dependency>
-    
+
             <dependency>
                 <groupId>org.codehaus.groovy</groupId>
                 <artifactId>groovy</artifactId>
@@ -432,43 +431,6 @@
     </distributionManagement>
 
     <profiles>
-        <profile>
-            <id>soul-dashboard</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
-            <properties>
-                <frontend.plugin.skip>false</frontend.plugin.skip>
-            </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>exec-maven-plugin</artifactId>
-                        <version>${exec-maven-plugin.version}</version>
-                        <executions>
-                            <execution>
-                                <id>git submodule update</id>
-                                <phase>initialize</phase>
-                                <inherited>false</inherited>
-                                <configuration>
-                                    <executable>git</executable>
-                                    <arguments>
-                                        <argument>submodule</argument>
-                                        <argument>update</argument>
-                                        <argument>--init</argument>
-                                        <argument>--recursive</argument>
-                                    </arguments>
-                                </configuration>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
         <profile>
             <id>release</id>
             <activation>

--- a/soul-admin/pom.xml
+++ b/soul-admin/pom.xml
@@ -254,45 +254,6 @@
                 </executions>
             </plugin>
 
-            <!--This is to package the frontend, if you don't need to configure frontend.plugin.skip=true locally.-->
-            <plugin>
-                <groupId>com.github.eirslett</groupId>
-                <artifactId>frontend-maven-plugin</artifactId>
-                <version>${frontend-maven-plugin.version}</version>
-                <configuration>
-                    <workingDirectory>${project.parent.basedir}/soul-dashboard</workingDirectory>
-                    <nodeVersion>${frontend-maven-plugin.node.version}</nodeVersion>
-                    <skip>${frontend.plugin.skip}</skip>
-                </configuration>
-                <executions>
-                    <!--If you have installed the nodejs environment locally, this step can also be annotated.-->
-                    <execution>
-                        <id>install node and npm</id>
-                        <goals>
-                            <goal>install-node-and-npm</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>npm install</id>
-                        <goals>
-                            <goal>npm</goal>
-                        </goals>
-                        <configuration>
-                            <arguments>install --registry=https://registry.npmjs.org/</arguments>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>npm run build</id>
-                        <goals>
-                            <goal>npm</goal>
-                        </goals>
-                        <configuration>
-                            <arguments>run build</arguments>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
@@ -300,20 +261,6 @@
                 <configuration>
                     <encoding>${project.build.sourceEncoding}</encoding>
                     <useDefaultDelimiters>true</useDefaultDelimiters>
-                    <resources>
-                        <resource>
-                            <targetPath>${basedir}/src/main/resources/static</targetPath>
-                            <directory>${project.parent.basedir}/soul-dashboard/dist</directory>
-                        </resource>
-                        <resource>
-                            <targetPath>${basedir}/target/classes</targetPath>
-                            <directory>src/main/resources</directory>
-                        </resource>
-                        <resource>
-                            <targetPath>${basedir}/target/test-classes</targetPath>
-                            <directory>src/test/resources</directory>
-                        </resource>
-                    </resources>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Currently soul and soul-dashboard were released separately. Avoid to update the submodule every time the `soul-dashboard` changed. I suggest that remove it for now.

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [ ] You have read the [contribution guidelines](https://dromara.org/projects/soul/contributor/).
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] Your local test passed `mvn clean install -Dmaven.javadoc.skip=true`.
